### PR TITLE
Improve Codex skill conversion and text normalization

### DIFF
--- a/tools/cli_adapters/codex.py
+++ b/tools/cli_adapters/codex.py
@@ -10,6 +10,7 @@ Codex CLI has built-in skill creator and installer support.
 """
 
 from pathlib import Path
+import re
 from typing import Optional
 
 from .base import CLIAdapter, SkillOutput
@@ -58,16 +59,29 @@ class CodexAdapter(CLIAdapter):
         Changes:
         - Remove Claude Code-specific syntax
         - Update directory references (templates → assets, docs → references)
+        - Remove Claude-specific hooks from frontmatter
+        - Replace Claude references and hook sections in body
         - Add Codex-specific usage section
         """
         # Apply common transformations
         content = self._common_skill_md_transforms(content)
+
+        # Remove Claude hook configuration from frontmatter if present
+        content = self._strip_hooks_from_frontmatter(content)
+
+        # Replace Claude Code references in body
+        content = self._replace_claude_references(content)
 
         # Update directory references
         content = content.replace("templates/", "assets/")
         content = content.replace("docs/", "references/")
         content = content.replace("`templates`", "`assets`")
         content = content.replace("`docs`", "`references`")
+
+        # Normalize slash invocation to Codex @skill syntax
+        content = re.sub(r'/(sf-[\w-]+)\b', r'@\1', content)
+        # Normalize Skill(...) shorthand in prose
+        content = re.sub(r'Skill\(\s*([a-zA-Z0-9_-]+)\s*\)\s*:?', r'@\1', content)
 
         # Add Codex-specific section
         codex_section = f"""
@@ -105,6 +119,103 @@ See `scripts/README.md` for validation script usage.
 
         return content
 
+    def _strip_hooks_from_frontmatter(self, content: str) -> str:
+        """
+        Remove Claude Code hooks from YAML frontmatter for Codex.
+
+        Keeps the rest of the frontmatter intact.
+        """
+        if not content.startswith("---"):
+            return content
+
+        # Match frontmatter block
+        match = re.match(r'^---\n(.*?)\n---\n', content, re.DOTALL)
+        if not match:
+            return content
+
+        frontmatter = match.group(1)
+        body = content[match.end():]
+
+        # Remove hooks block at top-level, preserving other keys
+        lines = frontmatter.splitlines()
+        cleaned = []
+        skipping = False
+        for line in lines:
+            if not skipping and re.match(r'^hooks:\s*$', line):
+                skipping = True
+                continue
+            if skipping:
+                # Stop skipping when we hit a new top-level key
+                if line and not line.startswith((" ", "\t")):
+                    skipping = False
+                else:
+                    continue
+            if not skipping:
+                cleaned.append(line)
+
+        frontmatter = "\n".join(cleaned)
+
+        # Clean up extra blank lines
+        frontmatter = re.sub(r'\n{3,}', '\n\n', frontmatter).strip()
+
+        return f"---\n{frontmatter}\n---\n{body}"
+
+    def _replace_claude_references(self, content: str) -> str:
+        """
+        Replace Claude Code references and remove hook-specific sections.
+        """
+        # Remove hook-related sections in body (headings containing Hook/Hooks)
+        content = re.sub(
+            r'\n#{2,}\s*[^#\n]*(Hook|Hooks)[^\n]*\n(?:.*\n)*?(?=\n#{2,}\s|\Z)',
+            '\n',
+            content,
+            flags=re.IGNORECASE
+        )
+
+        # Replace tool/platform mentions
+        replacements = [
+            (r'\bClaude Code\b', 'Codex CLI'),
+            (r'\bClaude\b', 'Codex'),
+            (r'\.claude/skills/', '.codex/skills/'),
+            (r'~/.claude/skills/', '~/.codex/skills/'),
+            (r'\.claude/', '.codex/'),
+            (r'~/.claude/', '~/.codex/'),
+        ]
+        for pattern, repl in replacements:
+            content = re.sub(pattern, repl, content)
+
+        return content
+
+    def _transform_text_files(self, files: dict) -> dict:
+        """
+        Apply Codex text transforms to any text file content in a dict.
+        """
+        transformed = {}
+        for path, content in files.items():
+            if not isinstance(content, str):
+                transformed[path] = content
+                continue
+
+            text = content
+            text = self._common_skill_md_transforms(text)
+            text = self._replace_claude_references(text)
+            text = text.replace("templates/", "assets/")
+            text = text.replace("docs/", "references/")
+            text = text.replace("`templates`", "`assets`")
+            text = text.replace("`docs`", "`references`")
+            text = re.sub(r'/(sf-[\w-]+)\b', r'@\1', text)
+            # Replace Skill(...) invocations in examples/scripts (handles escaped quotes)
+            text = re.sub(
+                r'Skill\(\s*skill=\\?"([^"]+)"(?:,\s*args=\\?"([^"]*)")?\s*\)',
+                r'@\1 \2',
+                text
+            )
+            text = re.sub(r'Skill\(\s*([a-zA-Z0-9_-]+)\s*\)', r'@\1', text)
+
+            transformed[path] = text
+
+        return transformed
+
     def transform_skill(self, source_dir: Path) -> SkillOutput:
         """
         Transform skill for Codex CLI.
@@ -113,6 +224,12 @@ See `scripts/README.md` for validation script usage.
         """
         # Get base transformation
         output = super().transform_skill(source_dir)
+
+        # Apply Codex transforms to bundled text files
+        output.scripts = self._transform_text_files(output.scripts)
+        output.templates = self._transform_text_files(output.templates)
+        output.docs = self._transform_text_files(output.docs)
+        output.examples = self._transform_text_files(output.examples)
 
         # Bundle shared modules if scripts reference them
         if self._needs_shared_modules(output.scripts):
@@ -136,10 +253,16 @@ See `scripts/README.md` for validation script usage.
         """Bundle shared modules for self-contained installation."""
         modules = {}
 
+        extra_exts = {".json", ".yml", ".yaml", ".txt", ".md", ".cfg", ".ini", ".xml"}
+
         # Bundle lsp-engine
         lsp_dir = self.shared_dir / "lsp-engine"
         if lsp_dir.exists():
-            for file_path in lsp_dir.rglob("*.py"):
+            for file_path in lsp_dir.rglob("*"):
+                if not file_path.is_file():
+                    continue
+                if file_path.suffix not in {".py", *extra_exts}:
+                    continue
                 rel_path = file_path.relative_to(self.shared_dir)
                 content = file_path.read_text(encoding='utf-8')
                 modules[str(rel_path)] = content
@@ -147,16 +270,11 @@ See `scripts/README.md` for validation script usage.
         # Bundle code_analyzer
         analyzer_dir = self.shared_dir / "code_analyzer"
         if analyzer_dir.exists():
-            for file_path in analyzer_dir.rglob("*.py"):
-                rel_path = file_path.relative_to(self.shared_dir)
-                content = file_path.read_text(encoding='utf-8')
-                modules[str(rel_path)] = content
-
-            for file_path in analyzer_dir.rglob("*.yml"):
-                rel_path = file_path.relative_to(self.shared_dir)
-                modules[str(rel_path)] = file_path.read_text(encoding='utf-8')
-
-            for file_path in analyzer_dir.rglob("*.xml"):
+            for file_path in analyzer_dir.rglob("*"):
+                if not file_path.is_file():
+                    continue
+                if file_path.suffix not in {".py", *extra_exts}:
+                    continue
                 rel_path = file_path.relative_to(self.shared_dir)
                 modules[str(rel_path)] = file_path.read_text(encoding='utf-8')
 

--- a/tools/installer.py
+++ b/tools/installer.py
@@ -89,10 +89,11 @@ def get_available_skills() -> List[str]:
     """
     skills = []
     for item in REPO_ROOT.iterdir():
-        if item.is_dir() and item.name.startswith("sf-"):
-            # Verify it has a SKILL.md
-            if (item / "SKILL.md").exists():
-                skills.append(item.name)
+        if not item.is_dir():
+            continue
+        # Any top-level directory with SKILL.md is a skill
+        if (item / "SKILL.md").exists():
+            skills.append(item.name)
     return sorted(skills)
 
 
@@ -216,7 +217,10 @@ def install_skills(
             continue
 
         if target_dir.exists() and force:
-            shutil.rmtree(target_dir)
+            try:
+                shutil.rmtree(target_dir)
+            except Exception as e:
+                print_warning(f"Could not remove {target_dir} ({e}); overwriting files in place")
 
         if install_skill(adapter, skill, target_base):
             success_count += 1


### PR DESCRIPTION
Improve Codex skill conversion and text normalization

Summary

Expand skill discovery to include any top-level [SKILL.md](https://file+.vscode-resource.vscode-cdn.net/Users/sarju.ladwa/.vscode/extensions/openai.chatgpt-0.4.71-darwin-arm64/webview/#).
Normalize Codex output across [SKILL.md](https://file+.vscode-resource.vscode-cdn.net/Users/sarju.ladwa/.vscode/extensions/openai.chatgpt-0.4.71-darwin-arm64/webview/#), references/, assets/, examples/, and scripts/.
Strip Claude hooks and replace Claude-specific paths and syntax with Codex conventions.
Bundle shared assets for Codex when needed.
Note: Codex doesn’t support the Claude YAML hook format, so hooks: are removed during conversion.
Testing

Manual: Regenerated .codex/skills and ran verification script (0 issues).