### PR TITLE
feat(hooks): extend guardrails to support Salesforce MCP server

### DIFF
--- a/shared/hooks/scripts/api-version-check.py
+++ b/shared/hooks/scripts/api-version-check.py
@@ -295,28 +295,51 @@ def format_output(check_result: Dict, operation: str, source_version: str, org_i
     return output
 
 
+def is_sf_mcp_deploy_retrieve(tool_name: str) -> Optional[str]:
+    """Check if MCP tool is a deploy or retrieve operation.
+
+    Returns operation type ("deploy" or "retrieve") or None.
+    """
+    name_lower = tool_name.lower()
+    if "deploy" in name_lower:
+        return "deploy"
+    if "retrieve" in name_lower:
+        return "retrieve"
+    return None
+
+
 def _process_hook(input_data: Dict) -> Dict:
     """Process the hook logic and return output."""
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
 
-    # Only process Bash tool
-    if tool_name != "Bash":
-        return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}
+    # Check for Salesforce MCP deploy/retrieve tools
+    is_sf_mcp = "salesforce" in tool_name.lower() or tool_name.startswith("mcp__salesforce")
+    if is_sf_mcp:
+        operation = is_sf_mcp_deploy_retrieve(tool_name)
+        if not operation:
+            return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}
+        # For MCP tools, extract target org from tool_input params
+        command = tool_input.get("usernameOrAlias", "") or ""
+        if command:
+            command = f"--target-org {command}"
+        # Fall through to version check with the extracted info
+    elif tool_name == "Bash":
+        # Get command
+        command = ""
+        if isinstance(tool_input, dict):
+            command = tool_input.get("command", "")
+        elif isinstance(tool_input, str):
+            command = tool_input
 
-    # Get command
-    command = ""
-    if isinstance(tool_input, dict):
-        command = tool_input.get("command", "")
-    elif isinstance(tool_input, str):
-        command = tool_input
+        if not command:
+            return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}
 
-    if not command:
-        return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}
-
-    # Check if it's a deploy/retrieve command
-    is_match, operation = is_deploy_retrieve_command(command)
-    if not is_match:
+        # Check if it's a deploy/retrieve command
+        is_match, operation = is_deploy_retrieve_command(command)
+        if not is_match:
+            return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}
+    else:
         return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}
 
     # Get source API version

--- a/shared/hooks/scripts/guardrails.py
+++ b/shared/hooks/scripts/guardrails.py
@@ -35,7 +35,7 @@ Add to .claude/hooks.json:
 {
     "hooks": {
         "PreToolUse": [{
-            "matcher": "Bash",
+            "matcher": "Bash|mcp__salesforce",
             "hooks": [{
                 "type": "command",
                 "command": "python3 ./shared/hooks/scripts/guardrails.py",
@@ -44,6 +44,9 @@ Add to .claude/hooks.json:
         }]
     }
 }
+
+Supports both Bash (sf CLI) and Salesforce MCP server tool calls.
+For MCP tools, all string values in tool_input are scanned for dangerous patterns.
 """
 
 import json
@@ -183,6 +186,29 @@ def load_registry() -> dict:
     except (json.JSONDecodeError, IOError):
         pass
     return {}
+
+
+def is_sf_mcp_tool(tool_name: str) -> bool:
+    """Check if the tool is a Salesforce MCP server tool."""
+    return "salesforce" in tool_name.lower() or tool_name.startswith("mcp__salesforce")
+
+
+def extract_checkable_text(tool_name: str, tool_input: dict) -> str:
+    """Extract text to check for dangerous patterns.
+
+    For Bash: returns the command string.
+    For Salesforce MCP tools: returns all string values from tool_input
+    concatenated, so the same pattern checks apply.
+    """
+    if tool_name == "Bash":
+        return tool_input.get("command", "")
+
+    # For MCP tools, concatenate all string values from the input
+    parts = []
+    for value in tool_input.values():
+        if isinstance(value, str) and len(value) > 3:
+            parts.append(value)
+    return " ".join(parts)
 
 
 def is_output_only_command(command: str) -> bool:
@@ -335,25 +361,26 @@ def main():
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
 
-    # Only process Bash commands
-    if tool_name != "Bash":
+    # Only process Bash commands and Salesforce MCP tool calls
+    if tool_name != "Bash" and not is_sf_mcp_tool(tool_name):
         print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}))
         sys.exit(0)
 
-    # Get the command
-    command = tool_input.get("command", "")
+    # Extract text to check from tool input (handles both Bash and MCP)
+    command = extract_checkable_text(tool_name, tool_input)
     if not command:
         print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}))
         sys.exit(0)
 
-    # Check if this is SF-related (skip guardrails for non-SF commands)
-    if not is_sf_context(command):
+    # For Bash, check if this is SF-related (skip guardrails for non-SF commands)
+    # MCP SF tools are inherently SF-related, so skip this check for them
+    if tool_name == "Bash" and not is_sf_context(command):
         print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}))
         sys.exit(0)
 
     # Skip guardrails for output-only commands (echo, printf, etc.)
-    # These just print text, they don't actually execute DML
-    if is_output_only_command(command):
+    # Only applies to Bash — MCP tools always execute
+    if tool_name == "Bash" and is_output_only_command(command):
         print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}))
         sys.exit(0)
 

--- a/tools/install.py
+++ b/tools/install.py
@@ -1334,7 +1334,7 @@ def get_hooks_config() -> Dict[str, Any]:
         ],
         "PreToolUse": [
             {
-                "matcher": "Bash",
+                "matcher": "Bash|mcp__salesforce",
                 "hooks": [
                     {
                         "type": "command",


### PR DESCRIPTION
## Description

The PreToolUse hooks (`guardrails.py`, `api-version-check.py`) only fire on `Bash` tool calls, leaving Salesforce MCP server operations (`run_soql_query`, `deploy_metadata`, `retrieve_metadata`) completely unprotected.

Users with the [Salesforce MCP server](https://developer.salesforce.com/tools/vscode/en/einstein/mcp-server) configured can bypass all guardrail checks since those operations go through `mcp__salesforce-dx__*` tool calls, never through Bash.

## Type of Change
- [x] Bug fix
- [x] New feature

## Changes

**guardrails.py:**
- `is_sf_mcp_tool()` — detects `mcp__salesforce-dx__*` tool names
- `extract_checkable_text()` — scans all string values from MCP tool input for dangerous patterns (DELETE without WHERE, hardcoded creds, production deploy without dry-run)
- MCP tools skip `is_sf_context()` and `is_output_only_command()` checks (inherently SF-related, always execute)

**api-version-check.py:**
- `is_sf_mcp_deploy_retrieve()` — detects deploy/retrieve MCP tools by tool name
- Extracts target org from `usernameOrAlias` param, falls through to existing version compatibility logic

**install.py:**
- PreToolUse matcher updated from `"Bash"` to `"Bash|mcp__salesforce"`

## Testing

- Verified Python syntax (`ast.parse`) on all 3 changed files
- Smoke tested `is_sf_mcp_tool()`, `extract_checkable_text()`, and `check_critical()` with both Bash and MCP inputs
- Confirmed existing Bash-only behavior is unchanged (guardrails correctly blocked a test command containing dangerous DML during development)

## Checklist
- [x] Updated documentation (docstrings in guardrails.py)
- [x] Tested manually
- [x] No breaking changes — existing Bash-only behavior preserved

## Context

Encountered this gap while installing sf-skills alongside the Salesforce DX MCP server in Claude Code. The hooks were designed for a Bash-only workflow; this extends them to also cover MCP tool calls without changing the existing Bash path.

Disclosure: AI-assisted implementation, manually reviewed and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)