### PR TITLE
fix(sf-docs): auto-create output dirs and add getting-started guide

### DIFF
--- a/skills/sf-docs/README.md
+++ b/skills/sf-docs/README.md
@@ -28,24 +28,31 @@ Official Salesforce documentation retrieval skill for `sf-skills`.
 - prefer official URLs and PDFs over third-party summaries
 - avoid broad crawling during normal question answering
 
-## Key References
+## Quick Start
 
-- [SKILL.md](./SKILL.md)
-- [references/local-corpus-layout.md](./references/local-corpus-layout.md)
-- [references/discovery-manifest.md](./references/discovery-manifest.md)
-- [references/qmd-integration.md](./references/qmd-integration.md)
-- [references/runtime-workflow.md](./references/runtime-workflow.md)
-- [references/ingestion-workflow.md](./references/ingestion-workflow.md)
-- [references/salesforce-scraper-techniques.md](./references/salesforce-scraper-techniques.md)
-- [references/pilot-scope.md](./references/pilot-scope.md)
-- [references/benchmark-protocol.md](./references/benchmark-protocol.md)
-- [references/cli-workflow.md](./references/cli-workflow.md)
+### Prerequisites
 
-## Unified CLI
+- Python 3.10+
+- qmd (optional — enables faster local search; without it, the skill uses Salesforce-aware scraping fallback)
 
-Use the wrapper CLI for the common end-to-end workflow:
+### Try it now (no setup required)
 
-### Discover / enrich the manifest
+Test sf-docs immediately without any corpus setup:
+
+```bash
+python3 skills/sf-docs/scripts/cli.py retrieve \
+  --query "System.StubProvider" \
+  --mode no_qmd \
+  --live-scrape
+```
+
+### Full local corpus setup
+
+The pilot corpus covers 7 guides: Apex Developer Guide, Apex Reference,
+REST API, Metadata API, Object Reference, LWC, and Agentforce.
+See [references/pilot-scope.md](./references/pilot-scope.md) for details.
+
+#### 1. Discover guides
 
 ```bash
 python3 skills/sf-docs/scripts/cli.py discover \
@@ -53,22 +60,34 @@ python3 skills/sf-docs/scripts/cli.py discover \
   --pretty
 ```
 
-### Sync a local corpus from the manifest
+Verify: `~/.sf-docs/manifest/guides.json` exists with 7 guides.
+
+#### 2. Sync corpus
 
 ```bash
 python3 skills/sf-docs/scripts/cli.py sync \
-  --manifest ~/.sf-docs/manifest/guides.json \
   --download-pdf \
-  --download-html \
-  --browser-scrape \
   --normalize
 ```
 
-### Bootstrap qmd for the local corpus
+Verify: `~/.sf-docs/normalized/md/` contains guide folders (e.g. `apexcode/`, `api_rest/`).
+
+#### 3. Bootstrap qmd (optional)
 
 ```bash
 python3 skills/sf-docs/scripts/cli.py bootstrap-qmd --embed
 ```
+
+Verify: `python3 skills/sf-docs/scripts/cli.py status` shows qmd collection indexed.
+
+#### 4. Test retrieval
+
+```bash
+python3 skills/sf-docs/scripts/cli.py retrieve \
+  --query "Find official Salesforce REST API authentication docs"
+```
+
+## CLI Reference
 
 ### Check qmd/corpus status
 
@@ -83,7 +102,7 @@ python3 skills/sf-docs/scripts/cli.py diagnose \
   --query "Find official Salesforce REST API authentication docs"
 ```
 
-### Run end-to-end retrieval
+### Run end-to-end retrieval (qmd-first mode)
 
 ```bash
 python3 skills/sf-docs/scripts/cli.py retrieve \
@@ -124,3 +143,16 @@ python3 skills/sf-docs/scripts/cli.py score-benchmark \
 ```
 
 > See [references/cli-workflow.md](./references/cli-workflow.md) for the recommended operator sequence.
+
+## Key References
+
+- [SKILL.md](./SKILL.md)
+- [references/local-corpus-layout.md](./references/local-corpus-layout.md)
+- [references/discovery-manifest.md](./references/discovery-manifest.md)
+- [references/qmd-integration.md](./references/qmd-integration.md)
+- [references/runtime-workflow.md](./references/runtime-workflow.md)
+- [references/ingestion-workflow.md](./references/ingestion-workflow.md)
+- [references/salesforce-scraper-techniques.md](./references/salesforce-scraper-techniques.md)
+- [references/pilot-scope.md](./references/pilot-scope.md)
+- [references/benchmark-protocol.md](./references/benchmark-protocol.md)
+- [references/cli-workflow.md](./references/cli-workflow.md)

--- a/skills/sf-docs/scripts/discover_salesforce_docs.py
+++ b/skills/sf-docs/scripts/discover_salesforce_docs.py
@@ -218,6 +218,7 @@ def main() -> int:
     args = parse_args()
     seed = load_seed(args.seed)
     manifest = build_manifest(seed, verify_pdf=args.verify_pdf)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
     if args.pretty:
         args.output.write_text(json.dumps(manifest, indent=2) + "\n")
     else:

--- a/skills/sf-docs/scripts/run_retrieval_benchmark.py
+++ b/skills/sf-docs/scripts/run_retrieval_benchmark.py
@@ -143,6 +143,7 @@ def main() -> int:
         },
         'results': [run_case(case, args.manifest.expanduser(), args.corpus_root.expanduser(), args.live_scrape) for case in benchmark.get('cases', [])],
     }
+    args.results.parent.mkdir(parents=True, exist_ok=True)
     args.results.write_text(json.dumps(out, indent=2) + '\n')
     print(f'Wrote benchmark results: {args.results}')
     print(f"Cases: {len(out['results'])}")


### PR DESCRIPTION
## Summary

- **Bug fix:** `discover` and `run-benchmark` scripts now auto-create parent directories before writing output files. Previously, running `cli.py discover` on a fresh system failed with `FileNotFoundError` because `~/.sf-docs/manifest/` didn't exist.
- **README restructured** with a Quick Start section: prerequisites (Python 3.10+, qmd optional), a "try it now" no-setup path (`--mode no_qmd --live-scrape`), sequenced corpus setup steps with verification after each step, and existing commands moved to a CLI Reference section.

Closes #39

## Test plan

- [ ] Remove `~/.sf-docs/manifest/` and run `cli.py discover --output ~/.sf-docs/manifest/guides.json --pretty` — should succeed without manual mkdir
- [ ] Run `cli.py run-benchmark --results /tmp/sf-docs-test/results.json` with a non-existent parent dir — should auto-create it
- [ ] Review README Quick Start for clarity and completeness