### PR TITLE
fix(sf-ai-agentscript): Document Draft prompt template misleading publish errors

### DIFF
--- a/skills/sf-ai-agentscript/SKILL.md
+++ b/skills/sf-ai-agentscript/SKILL.md
@@ -193,6 +193,7 @@ See [references/instruction-resolution.md](references/instruction-resolution.md)
 | Symptom | Likely cause | Read next |
 |---|---|---|
 | `Internal Error` during publish | invalid Service Agent user or missing action I/O | [references/agent-user-setup.md](references/agent-user-setup.md), [references/actions-reference.md](references/actions-reference.md) |
+| `invalid input/output parameters` on prompt template action | **Target template is in Draft status** — activate it first | [references/action-prompt-templates.md](references/action-prompt-templates.md#draft-template-publish-errors) |
 | Parser rejects conditionals | `else if`, nested `if`, empty `if` body | [references/syntax-reference.md](references/syntax-reference.md) |
 | Action target issues | missing Flow / Apex target, inactive Flow, bad schemas | [references/actions-reference.md](references/actions-reference.md) |
 | Preview and runtime disagree | linked vars / context / known platform issues | [references/known-issues.md](references/known-issues.md) |

--- a/skills/sf-ai-agentscript/references/action-prompt-templates.md
+++ b/skills/sf-ai-agentscript/references/action-prompt-templates.md
@@ -147,6 +147,34 @@ generate_summary: @actions.Generate_Order_Summary
 
 ---
 
+## Draft Template Publish Errors (Critical)
+
+> **If your `generatePromptResponse://` action fails to publish, check the template status FIRST.** A Draft template produces a cascade of misleading errors — none of which mention the template status.
+
+When the target prompt template is in **Draft** status, `sf agent publish authoring-bundle` reports different errors depending on which I/O blocks are present. All are caused by the same root cause:
+
+| Agent Script State | Error Message | Actually Means |
+|---|---|---|
+| Full I/O (`inputs:` + `outputs:`) | `invalid input parameters found: 'Input:query'` | Template can't be resolved (Draft) |
+| `outputs:` only | `invalid output parameters found: 'promptResponse'` | Template can't be resolved (Draft) |
+| Bare definition (no I/O) | `Metadata API request failed: Metadata retrieval failed:` | Template can't be resolved (Draft) |
+| Bare definition (retry) | `Internal Error, try again later` | Template can't be resolved (Draft) |
+
+**`sf agent validate authoring-bundle` passes regardless of template status** — it does not check whether the target template is Active. This gives false confidence before publish.
+
+**Fix**: Activate the template in **Setup > Prompt Builder** before publishing. The original Agent Script syntax (with `"Input:X"` inputs and `promptResponse` output) is correct — it will publish successfully once the template is Active.
+
+**Pre-publish check**:
+```bash
+sf project retrieve start --metadata GenAiPromptTemplate:YourTemplateName -o TARGET_ORG --json
+# Then inspect the retrieved XML for <status>Published</status> or <status>Active</status>
+# Draft status = publish will fail with misleading errors
+```
+
+> See [known-issues.md](known-issues.md#issue-40) Issue 40 for the full bug report.
+
+---
+
 ## Common Errors
 
 | Error | Cause | Fix |
@@ -155,12 +183,14 @@ generate_summary: @actions.Generate_Order_Summary
 | Template not found | Wrong protocol or template name | Verify `generatePromptResponse://ExactTemplateName` |
 | Empty `promptResponse` | Template inactive or missing required inputs | Activate template in Setup, check all `is_required: True` inputs are bound |
 | Input not mapped | API name mismatch | Input field name after `Input:` must exactly match template's input API name |
+| `invalid input/output parameters found` | Target template is in **Draft** status | Activate the template in Setup > Prompt Builder — see "Draft Template Publish Errors" above |
+| `Internal Error` with bare action definition | Missing I/O blocks AND/OR Draft template | Add `inputs:`/`outputs:` blocks and ensure template is Active |
 
 ---
 
 ## Checklist
 
-- [ ] Template exists in org and is **active**
+- [ ] Template exists in org and is **active** (Draft templates cause misleading publish errors)
 - [ ] Input field API names match template configuration exactly
 - [ ] All `is_required: True` inputs are bound (via `...`, `@variables`, or fixed)
 - [ ] `promptResponse` output is captured with `set`

--- a/skills/sf-ai-agentscript/references/known-issues.md
+++ b/skills/sf-ai-agentscript/references/known-issues.md
@@ -684,6 +684,20 @@
 
 ---
 
+<a id="issue-40"></a>
+
+### Issue 40: Draft prompt template causes misleading publish errors for `generatePromptResponse://` actions
+- **Status**: WORKAROUND
+- **Date Discovered**: 2026-03-17
+- **Affects**: `sf agent publish authoring-bundle` with `generatePromptResponse://` action targets
+- **Symptom**: Publish fails with `invalid input parameters found: 'Input:query'` or `invalid output parameters found: 'promptResponse'` — implying the I/O names are wrong. Removing I/O blocks produces `Metadata API request failed: Metadata retrieval failed:` or `Internal Error, try again later`. `sf agent validate authoring-bundle` passes in all cases.
+- **Root Cause**: The target prompt template is in **Draft** status. The platform cannot resolve the `generatePromptResponse://` target, but reports the failure as invalid I/O parameters or generic internal errors rather than indicating the template status.
+- **Workaround**: Activate the prompt template in **Setup > Prompt Builder** before publishing. The original Agent Script syntax (with `"Input:X"` inputs and `promptResponse` output) publishes successfully once the template is Active. Pre-publish check: retrieve the template XML and verify `<status>Published</status>` or `<status>Active</status>`.
+- **Open Questions**: Will Salesforce improve the error message to mention template status? Will `sf agent validate` add a target resolution check?
+- **References**: [action-prompt-templates.md](action-prompt-templates.md#draft-template-publish-errors) — "Draft Template Publish Errors" section
+
+---
+
 ## Resolved Issues
 
 <a id="issue-16"></a>


### PR DESCRIPTION
## Summary

Draft prompt templates used as `generatePromptResponse://` targets cause a cascade of misleading publish errors. This PR documents the behavior and ensures the skill guides users to check template status before debugging syntax.

## Problem

When an Agent Script action targets a prompt template via `generatePromptResponse://` and the template is in **Draft** status, `sf agent publish authoring-bundle` fails with errors that blame the I/O parameter names — not the template status:

| Agent Script State | Error Message |
|---|---|
| Full I/O (`inputs:` + `outputs:`) | `invalid input parameters found: 'Input:query'` |
| `outputs:` only | `invalid output parameters found: 'promptResponse'` |
| Bare definition (no I/O) | `Metadata API request failed: Metadata retrieval failed:` |
| Bare definition (retry) | `Internal Error, try again later` |

`sf agent validate authoring-bundle` **passes in all cases**, giving false confidence.

Activating the template resolves every error with **zero code changes** to the `.agent` file.

## Discovery Context

Found during a sandbox FDE engagement (API v66.0, sf CLI 2.126.4). Lost 4+ publish iterations before identifying the root cause. The agent's `"Input:query"` + `promptResponse` syntax was correct from the start — the Draft template was the sole blocker.

## Changes

- **`action-prompt-templates.md`**: New "Draft Template Publish Errors" section with error cascade table, pre-publish retrieval check command, and two new rows in the Common Errors table
- **`known-issues.md`**: Issue 40 — full bug report with symptom, root cause, workaround
- **`SKILL.md`**: New row in High-Signal Failure Patterns table pointing to the prompt template Draft status as a likely cause for `invalid input/output` errors

## Suggested Follow-Up

Consider adding a validator rule (e.g., `ASV-ORG-006`) that retrieves the target template metadata and warns if `<status>Draft</status>` is detected for `generatePromptResponse://` targets. This would catch the issue at validation time rather than publish time.
