### PR TITLE
feat(sf-flow): Add AI Decision element support

### DIFF
--- a/skills/sf-flow/SKILL.md
+++ b/skills/sf-flow/SKILL.md
@@ -63,6 +63,7 @@ Before building, confirm Flow is the right answer rather than:
 | reusable background logic | autolaunched / subflow |
 | scheduled processing | scheduled flow |
 | event-driven declarative response | platform-event flow |
+| AI-evaluated routing (sentiment, intent, tone) | autolaunched with AI Decision element |
 
 ### 3. Start from a template
 Prefer the provided assets:
@@ -72,6 +73,7 @@ Prefer the provided assets:
 - `assets/autolaunched-flow-template.xml`
 - `assets/scheduled-flow-template.xml`
 - `assets/platform-event-flow-template.xml`
+- `assets/ai-decision-template.xml`
 - `assets/subflows/`
 
 ### 4. Validate against Flow guardrails
@@ -81,6 +83,8 @@ Focus on:
 - proper fault paths
 - correct trigger conditions
 - safe subflow composition
+- AI Decision elements not placed inside loops (credit cost per iteration)
+- AI Decision prompts include merge field references for data context
 
 ### 5. Hand off deployment and testing
 Use:
@@ -161,6 +165,9 @@ Next step: <dry-run deploy, activate, or test>
 - [references/orchestration-parent-child.md](references/orchestration-parent-child.md)
 - [references/orchestration-sequential.md](references/orchestration-sequential.md)
 - [references/orchestration-conditional.md](references/orchestration-conditional.md)
+
+### AI Decision
+- [references/ai-decision-guide.md](references/ai-decision-guide.md)
 
 ### Screen / integration / troubleshooting
 - [references/form-building-guide.md](references/form-building-guide.md)

--- a/skills/sf-flow/assets/ai-decision-template.xml
+++ b/skills/sf-flow/assets/ai-decision-template.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    AI Decision Element Template
+    ============================
+    Use "Define with AI (Advanced)" in Flow Builder to let AI evaluate
+    conditions at runtime instead of manually defined criteria.
+
+    Key structure:
+    - <attributes><type>LlmPrompt</type> on the <decisions> element = Decision Instructions
+    - <attributes><type>LlmPrompt</type> on each <rules> element    = Outcome Instructions
+    - No <conditions> block needed on AI-evaluated rules
+    - The default outcome path needs no AI instructions
+
+    Requirements:
+    - API version 62.0+
+    - Einstein AI credits (consumed per evaluation)
+    - Include merge field references in prompts so AI has data context
+
+    Usage:
+    Replace {{PLACEHOLDERS}} with your values.
+-->
+<decisions>
+    <name>{{DECISION_API_NAME}}</name>
+    <label>{{Decision Label}}</label>
+    <locationX>182</locationX>
+    <locationY>242</locationY>
+
+    <!-- Decision Instructions: describes what the AI is deciding -->
+    <attributes>
+        <type>LlmPrompt</type>
+        <value>{{Describe the decision. Include merge field references like {!Get_Record.FieldName} so AI has the data it needs to evaluate. Example: Detect the sentiment on the case based on subject "{!Get_Case.Subject}" and description "{!Get_Case.Description}" as Negative, Positive, Neutral, or Undetermined.}}</value>
+    </attributes>
+
+    <!-- Default outcome: catches everything that doesn't match a named rule -->
+    <defaultConnector>
+        <targetReference>{{DEFAULT_PATH_TARGET}}</targetReference>
+    </defaultConnector>
+    <defaultConnectorLabel>{{Default Outcome Label}}</defaultConnectorLabel>
+
+    <!-- Named outcome: AI routes here when its instructions match -->
+    <rules>
+        <name>{{OUTCOME_API_NAME}}</name>
+
+        <!-- Outcome Instructions: describes when AI should choose this path -->
+        <attributes>
+            <type>LlmPrompt</type>
+            <value>{{Describe when this outcome applies. Example: The customer sentiment is Negative. The subject or description contains language indicating frustration, anger, dissatisfaction, complaint, or urgency.}}</value>
+        </attributes>
+
+        <conditionLogic>and</conditionLogic>
+        <connector>
+            <targetReference>{{OUTCOME_PATH_TARGET}}</targetReference>
+        </connector>
+        <label>{{Outcome Label}}</label>
+    </rules>
+
+    <!-- Add more <rules> blocks for additional AI-evaluated outcomes -->
+</decisions>

--- a/skills/sf-flow/references/ai-decision-guide.md
+++ b/skills/sf-flow/references/ai-decision-guide.md
@@ -1,0 +1,124 @@
+# AI Decision Element Guide
+
+## Overview
+
+The AI Decision element ("Define with AI") lets AI evaluate flow data at runtime to determine which outcome path to follow. Instead of manually defining conditions (e.g., "Status equals Closed"), you write natural-language instructions and AI decides which outcome fires.
+
+Introduced in API version 62.0 (Spring '25). Requires Einstein AI credits.
+
+---
+
+## XML Structure
+
+An AI Decision is a standard `<decisions>` element with `<attributes>` blocks of type `LlmPrompt`. There is no separate element type — the `<attributes>` block is the only difference from a manual decision.
+
+### Decision-level instructions
+
+```xml
+<decisions>
+    <name>Route_Case_Based_on_Sentiment</name>
+    <label>Route Case Based on Sentiment</label>
+    <attributes>
+        <type>LlmPrompt</type>
+        <value>Detect the sentiment on the case based on subject
+        &quot;{!Get_Case.Subject}&quot; and description
+        &quot;{!Get_Case.Description}&quot; as Negative, Positive,
+        Neutral, or Undetermined.</value>
+    </attributes>
+    <defaultConnector>
+        <targetReference>Handle_Default</targetReference>
+    </defaultConnector>
+    <defaultConnectorLabel>Not Negative</defaultConnectorLabel>
+    <rules>
+        ...
+    </rules>
+</decisions>
+```
+
+### Outcome-level instructions
+
+Each `<rules>` block (outcome) also gets an `<attributes>` block describing when AI should choose that path:
+
+```xml
+<rules>
+    <name>Negative</name>
+    <attributes>
+        <type>LlmPrompt</type>
+        <value>The customer&apos;s sentiment is Negative. The case
+        subject or description contains language indicating frustration,
+        anger, dissatisfaction, complaint, or urgency.</value>
+    </attributes>
+    <conditionLogic>and</conditionLogic>
+    <connector>
+        <targetReference>Assign_to_Senior_Support</targetReference>
+    </connector>
+    <label>Negative</label>
+</rules>
+```
+
+### Key structural notes
+
+| Aspect | Detail |
+|---|---|
+| Element type | Standard `<decisions>` — no new XML element |
+| AI marker | `<attributes><type>LlmPrompt</type><value>...</value></attributes>` |
+| Decision instructions | `<attributes>` as a direct child of `<decisions>` |
+| Outcome instructions | `<attributes>` as a direct child of each `<rules>` |
+| Conditions | No `<conditions>` block needed; `<conditionLogic>and</conditionLogic>` is present but vestigial |
+| Default outcome | No `<attributes>` block needed — it catches everything not matched |
+| Merge fields | Use `{!Element.Field}` references in prompt text so AI has data context |
+| XML escaping | `&quot;` for quotes, `&apos;` for apostrophes inside `<value>` |
+
+---
+
+## When to Use AI Decision vs Manual Decision
+
+| Use AI Decision when | Use manual Decision when |
+|---|---|
+| Conditions are subjective (sentiment, intent, tone) | Conditions are objective (status = "Closed") |
+| You need NLP-style evaluation of free-text fields | You're comparing picklist or numeric values |
+| The routing logic would require many complex rules | A few simple conditions cover all cases |
+| You want flexible, less predetermined outcomes | Deterministic behavior is required |
+
+---
+
+## Writing Effective Instructions
+
+### Decision Instructions (element level)
+- Describe the **overall decision** the AI is making
+- Include **merge field references** (`{!Get_Case.Subject}`) so AI has data
+- List all possible categories the AI should classify into
+- Be specific about what data to evaluate
+
+**Good:**
+> Detect the sentiment on the case based on subject "{!Get_Case.Subject}" and description "{!Get_Case.Description}" as Negative, Positive, Neutral, or Undetermined.
+
+**Bad:**
+> Figure out the sentiment.
+
+### Outcome Instructions (rule level)
+- Describe **when this specific outcome applies**
+- Include concrete indicators or signals AI should look for
+- Be mutually exclusive with other outcomes where possible
+
+**Good:**
+> The customer's sentiment is Negative. The subject or description contains language indicating frustration, anger, dissatisfaction, complaint, or urgency.
+
+**Bad:**
+> Negative sentiment.
+
+---
+
+## Governance and Cost
+
+- Each AI Decision evaluation **consumes Einstein credits**. Monitor usage in Setup > Digital Wallet.
+- Avoid placing AI Decision elements inside loops — each iteration costs credits.
+- AI Decision adds latency (LLM call) — not suitable for high-volume record-triggered flows.
+- Best suited for **autolaunched flows, screen flows, or low-volume triggers**.
+- Debug your automation to verify AI is routing to the correct outcome before activation.
+
+---
+
+## Template
+
+See [`assets/ai-decision-template.xml`](../assets/ai-decision-template.xml) for a copy-paste starting point.


### PR DESCRIPTION
## Summary

- Adds **AI Decision element** support to the `sf-flow` skill — template, reference guide, and SKILL.md updates
- The XML structure was reverse-engineered by deploying a skeleton flow, configuring the AI Decision in Flow Builder, and retrieving the metadata to discover the actual serialization format

## What's new

### `assets/ai-decision-template.xml`
Copy-paste XML template for the AI Decision element showing the `<attributes><type>LlmPrompt</type>` pattern at both the decision and outcome levels, with placeholder instructions.

### `references/ai-decision-guide.md`
Comprehensive guide covering:
- Exact XML structure (`<attributes>` blocks on `<decisions>` and `<rules>`)
- When to use AI Decision vs manual Decision
- Writing effective decision/outcome instructions
- Governance (Einstein credit consumption, loop avoidance, latency)

### `SKILL.md` updates
- New row in "Choose the right Flow type" table for AI-evaluated routing
- `ai-decision-template.xml` added to template list
- Two new guardrail items (no AI Decision in loops, merge fields in prompts)
- `ai-decision-guide.md` added to Reference Map

## Key discovery

The AI Decision element is **not** a new XML element type. It's a standard `<decisions>` element with `<attributes>` child blocks:

```xml
<decisions>
    <name>Route_Case_Based_on_Sentiment</name>
    <attributes>
        <type>LlmPrompt</type>
        <value>Detect the sentiment on the case...</value>
    </attributes>
    <rules>
        <name>Negative</name>
        <attributes>
            <type>LlmPrompt</type>
            <value>The customer sentiment is Negative...</value>
        </attributes>
        <conditionLogic>and</conditionLogic>
        <label>Negative</label>
    </rules>
</decisions>
```

This is not documented in the Salesforce Metadata API docs as of March 2026 — it was discovered empirically.

## Test plan

- [ ] Deploy the `ai-decision-template.xml` to a scratch org (with placeholders replaced) and verify it saves
- [ ] Open the deployed flow in Flow Builder and confirm the AI Decision UI renders correctly
- [ ] Verify SKILL.md renders cleanly in GitHub markdown preview