### PR TITLE
fix(sf-apex,hooks): eliminate false-positive loop detection and guardrail context matching

### DIFF
--- a/shared/hooks/scripts/guardrails.py
+++ b/shared/hooks/scripts/guardrails.py
@@ -230,13 +230,15 @@ def is_output_only_command(command: str) -> bool:
 
 
 def is_sf_context(command: str) -> bool:
-    """Check if command is Salesforce-related."""
+    """Check if command is Salesforce-related (ignoring quoted argument content)."""
+    # Strip quoted strings so keywords inside argument values don't trigger
+    stripped = re.sub(r"""(['"])(?:(?!\1).)*\1""", '""', command)
     sf_indicators = [
         r'\bsf\b', r'\bsfdx\b', r'SELECT\s+', r'DELETE\s+FROM', r'UPDATE\s+\w+\s+SET',
         r'force-app', r'\.cls\b', r'\.trigger\b', r'\.flow-meta', r'scratch\s*org',
         r'--target-org', r'--source-org', r'apex\s+run', r'data\s+query'
     ]
-    return any(re.search(p, command, re.IGNORECASE) for p in sf_indicators)
+    return any(re.search(p, stripped, re.IGNORECASE) for p in sf_indicators)
 
 
 def check_critical(command: str) -> Optional[Dict[str, Any]]:

--- a/skills/sf-apex/hooks/scripts/validate_apex.py
+++ b/skills/sf-apex/hooks/scripts/validate_apex.py
@@ -111,37 +111,31 @@ class ApexValidator:
 
     def _check_soql_in_loops(self):
         """Check for SOQL queries inside loops (critical anti-pattern)."""
-        loop_depth = 0
-        loop_start_line = 0
+        loop_stack = []  # list of {'start': line_num, 'depth': brace_depth}
 
-        # Patterns for loops
         loop_patterns = [
             r'\bfor\s*\(',
             r'\bwhile\s*\(',
             r'\bdo\s*\{'
         ]
-
-        # Pattern for SOQL
         soql_pattern = r'\[\s*SELECT\s+'
 
         for i, line in enumerate(self.lines, 1):
-            # Check for loop start
             for pattern in loop_patterns:
                 if re.search(pattern, line, re.IGNORECASE):
-                    if loop_depth == 0:
-                        loop_start_line = i
-                    loop_depth += 1
+                    loop_stack.append({'start': i, 'depth': 0})
 
-            # Check for loop end (simplified - counts braces)
-            loop_depth += line.count('{') - line.count('}')
-            loop_depth = max(0, loop_depth)
+            open_braces = line.count('{')
+            close_braces = line.count('}')
+            for scope in loop_stack:
+                scope['depth'] += open_braces - close_braces
+            loop_stack = [s for s in loop_stack if s['depth'] > 0]
 
-            # Check for SOQL inside loop
-            if loop_depth > 0 and re.search(soql_pattern, line, re.IGNORECASE):
+            if loop_stack and re.search(soql_pattern, line, re.IGNORECASE):
                 self.issues.append({
                     'severity': 'CRITICAL',
                     'category': 'bulkification',
-                    'message': f'SOQL query inside loop (loop started line {loop_start_line})',
+                    'message': f'SOQL query inside loop (loop started line {loop_stack[0]["start"]})',
                     'line': i,
                     'fix': 'Move SOQL before loop, query all needed records, filter in loop'
                 })
@@ -149,8 +143,7 @@ class ApexValidator:
 
     def _check_dml_in_loops(self):
         """Check for DML operations inside loops (critical anti-pattern)."""
-        loop_depth = 0
-        loop_start_line = 0
+        loop_stack = []  # list of {'start': line_num, 'depth': brace_depth}
 
         loop_patterns = [
             r'\bfor\s*\(',
@@ -170,20 +163,21 @@ class ApexValidator:
         for i, line in enumerate(self.lines, 1):
             for pattern in loop_patterns:
                 if re.search(pattern, line, re.IGNORECASE):
-                    if loop_depth == 0:
-                        loop_start_line = i
-                    loop_depth += 1
+                    loop_stack.append({'start': i, 'depth': 0})
 
-            loop_depth += line.count('{') - line.count('}')
-            loop_depth = max(0, loop_depth)
+            open_braces = line.count('{')
+            close_braces = line.count('}')
+            for scope in loop_stack:
+                scope['depth'] += open_braces - close_braces
+            loop_stack = [s for s in loop_stack if s['depth'] > 0]
 
-            if loop_depth > 0:
+            if loop_stack:
                 for dml_pattern in dml_patterns:
                     if re.search(dml_pattern, line, re.IGNORECASE):
                         self.issues.append({
                             'severity': 'CRITICAL',
                             'category': 'bulkification',
-                            'message': f'DML inside loop (loop started line {loop_start_line})',
+                            'message': f'DML inside loop (loop started line {loop_stack[0]["start"]})',
                             'line': i,
                             'fix': 'Collect records in loop, perform single DML after loop'
                         })


### PR DESCRIPTION
## Summary

- **Loop detection**: replace depth counter with stack-based tracking in `validate_apex.py` so brace counting only applies to scopes initiated by a loop keyword — eliminates "loop started line 0" false positives from non-loop braces (class bodies, `if`/`try` blocks)
- **Guardrail context**: strip quoted strings before matching SF indicators in `is_sf_context()` so keywords inside argument values (e.g., SOQL examples in `gh --body`) don't trigger false warnings

Closes #47

## Test plan

- [ ] Create `.cls` with SOQL/DML inside `if`/`try`/plain blocks → no bulkification findings
- [ ] Create `.cls` with SOQL/DML inside `for`/`while`/`do` loops → CRITICAL findings with correct line numbers (≥ 1)
- [ ] Run `gh` command with quoted SOQL in body → no guardrail warning
- [ ] Run `sf data query` with quoted SOQL → guardrail warning fires
- [ ] Run command with unquoted SF path (e.g., `cat force-app/foo.cls`) → guardrail warning fires