### PR TITLE
Add Agentforce Agent API skill as /sf-ai-agentforce-agent-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Author](https://img.shields.io/badge/Author-Jag_Valaiyapathy-blue?logo=github)](https://github.com/Jaganpro)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Skills](https://img.shields.io/badge/Skills-36-4F46E5)](#available-skills)
+[![Skills](https://img.shields.io/badge/Skills-37-4F46E5)](#available-skills)
 [![Claude Code Agents](https://img.shields.io/badge/Claude_Code_Agents-7-059669)](#agent-team)
 [![Standard](https://img.shields.io/badge/Agent_Skills-Compatible-0F766E)](https://agentskills.io)
 
@@ -34,7 +34,7 @@ The library is organized by capability area so you can scan quickly, pick the ri
 | 🔌 **Integration** | [sf-connected-apps](skills/sf-connected-apps/), [sf-integration](skills/sf-integration/) | OAuth, External Client Apps, Named Credentials, callouts, and events |
 | 💰 **Planning & Estimation** | [sf-flex-estimator](skills/sf-flex-estimator/) | Public list-price Flex Credit estimation, scenario planning, and cost optimization for Agentforce and Data Cloud |
 | ☁️ **Data Cloud** | [sf-datacloud](skills/sf-datacloud/), [sf-datacloud-connect](skills/sf-datacloud-connect/), [sf-datacloud-prepare](skills/sf-datacloud-prepare/), [sf-datacloud-harmonize](skills/sf-datacloud-harmonize/), [sf-datacloud-segment](skills/sf-datacloud-segment/), [sf-datacloud-act](skills/sf-datacloud-act/), [sf-datacloud-retrieve](skills/sf-datacloud-retrieve/) | Data Cloud connections, ingestion, harmonization, segmentation, activation, and retrieval.<br><sub>Beta / Community Preview · live execution uses the external community <code>sf data360</code> runtime</sub> |
-| 🤖 **AI & Automation** | [sf-ai-agentscript](skills/sf-ai-agentscript/), [sf-ai-agentforce](skills/sf-ai-agentforce/), [sf-ai-agentforce-testing](skills/sf-ai-agentforce-testing/), [sf-ai-agentforce-observability](skills/sf-ai-agentforce-observability/), [sf-ai-agentforce-persona](skills/sf-ai-agentforce-persona/) | Agent design, Agent Script, testing, observability, and persona design |
+| 🤖 **AI & Automation** | [sf-ai-agentscript](skills/sf-ai-agentscript/), [sf-ai-agentforce](skills/sf-ai-agentforce/), [sf-agentforce-agent-api](skills/sf-agentforce-agent-api/), [sf-ai-agentforce-testing](skills/sf-ai-agentforce-testing/), [sf-ai-agentforce-observability](skills/sf-ai-agentforce-observability/), [sf-ai-agentforce-persona](skills/sf-ai-agentforce-persona/) | Agent design, Agent Script, Agent API integration, testing, observability, and persona design |
 | 🚀 **DevOps & Tooling** | [sf-deploy](skills/sf-deploy/), [sf-vlocity-build-deploy](skills/sf-vlocity-build-deploy/), [sf-diagram-mermaid](skills/sf-diagram-mermaid/), [sf-diagram-nanobananapro](skills/sf-diagram-nanobananapro/) | Salesforce + Vlocity DataPack deployment automation, Mermaid diagrams, and visual artifacts |
 | 🏢 **Industries** | [sf-industry-commoncore-omnistudio-analyze](skills/sf-industry-commoncore-omnistudio-analyze/), [sf-industry-commoncore-datamapper](skills/sf-industry-commoncore-datamapper/), [sf-industry-commoncore-integration-procedure](skills/sf-industry-commoncore-integration-procedure/), [sf-industry-commoncore-callable-apex](skills/sf-industry-commoncore-callable-apex/), [sf-industry-commoncore-omniscript](skills/sf-industry-commoncore-omniscript/), [sf-industry-commoncore-flexcard](skills/sf-industry-commoncore-flexcard/), [sf-industry-cme-epc-model](skills/sf-industry-cme-epc-model/) | OmniStudio + EPC: dependency analysis, Data Mappers, Integration Procedures, callable Apex, OmniScripts, FlexCards, and CME product/offer catalog modeling |
 
@@ -621,6 +621,7 @@ sf-industry-commoncore-{name}  # Industries Common Core (omnistudio)
 | | Skill | Description | Status |
 |--|-------|-------------|--------|
 | 🤖 | `sf-ai-agentforce` | Agent Builder, PromptTemplate, Models API, GenAi metadata | ✅ Live |
+| 🤖 | `sf-agentforce-agent-api` | Agent API, Mobile SDKs, Enhanced Chat v2, Testing API | ✅ Live |
 | 🧪 | `sf-ai-agentforce-testing` | Agent test specs, agentic fix loops | ✅ Live |
 | 📈 | `sf-ai-agentforce-observability` | STDM + Builder trace capture, trace-test, and execution analysis | ✅ Live |
 | 📝 | `sf-ai-agentscript` | Agent Script DSL, FSM patterns, 100-pt scoring | ✅ Live |
@@ -664,7 +665,7 @@ sf-industry-commoncore-{name}  # Industries Common Core (omnistudio)
 | 🏦 | `sf-industry-finserv` | KYC, AML, Wealth Management | 📋 Planned |
 | 💵 | `sf-industry-revenue` | CPQ, Billing, Revenue Lifecycle | 📋 Planned |
 
-**Current repo state:** 36 live skills today, with additional cloud, security, AI, and industry roadmap items still planned.
+**Current repo state:** 37 live skills today, with additional cloud, security, AI, and industry roadmap items still planned.
 
 </details>
 

--- a/skills/sf-agentforce-agent-api/SKILL.md
+++ b/skills/sf-agentforce-agent-api/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: sf-agentforce-agent-api
+description: >
+  Agentforce API integration for the REST Agent API, Mobile SDKs, Enhanced Chat
+  v2, and Testing API workflows. TRIGGER when the user needs Agent API
+  authentication, session lifecycle guidance, agent ID lookup, variable
+  handling, token caching, mobile/web chat setup, testing, or troubleshooting.
+license: MIT
+compatibility: "Requires Agentforce enabled orgs and Salesforce API access"
+metadata:
+  version: "1.0.0"
+  author: "Jag Valaiyapathy"
+---
+
+# sf-agentforce-agent-api: Agentforce API Integration
+
+Use this skill when integrating Salesforce Agentforce agents into external apps. It covers the Agent API, authentication, Mobile SDKs, Enhanced Chat v2, Testing API, and common pitfalls.
+
+## Quick Start — Minimum Viable Call
+
+Three steps to talk to an agent:
+
+### 1. Get a Token
+
+```
+POST https://{MY_DOMAIN}/services/oauth2/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials&client_id={KEY}&client_secret={SECRET}
+```
+
+Requires an External Client App with Client Credentials flow. Full setup in [references/auth-setup.md](references/auth-setup.md).
+
+### 2. Start a Session
+
+```
+POST https://api.salesforce.com/einstein/ai-agent/v1/agents/{AGENT_ID}/sessions
+Authorization: Bearer {TOKEN}
+Content-Type: application/json
+```
+
+```json
+{
+  "externalSessionKey": "<uuid>",
+  "instanceConfig": { "endpoint": "https://{MY_DOMAIN}" },
+  "streamingCapabilities": { "chunkTypes": ["Text"] },
+  "bypassUser": true
+}
+```
+
+### 3. Send a Message
+
+```
+POST https://api.salesforce.com/einstein/ai-agent/v1/sessions/{SESSION_ID}/messages
+Authorization: Bearer {TOKEN}
+Content-Type: application/json
+```
+
+```json
+{
+  "message": { "type": "Text", "text": "Hello!", "sequenceId": 1 }
+}
+```
+
+Response text is in `messages[].message` (not `.text`). Increment `sequenceId` per turn.
+
+---
+
+## Critical Rules
+
+1. **API host**: Always `api.salesforce.com/einstein/ai-agent/v1` — My Domain goes in the body only
+2. **sequenceId**: Must be **inside** the `message` object, not at the root
+3. **Response field**: Text lives in `messages[].message`, not `messages[].text`
+4. **Run As user**: Must have a full Salesforce license — never use Einstein Agent service users
+5. **Token caching**: Mandatory. Salesforce enforces 3,600 logins/user/hour
+6. **Env var trimming**: Always `.trim()` — hosting platforms can add trailing `\n`
+7. **Agent type**: Agent API is **not supported** for "Agentforce (Default)" agents
+8. **Timeout**: 120-second timeout per call; HTTP 500 on timeout
+
+## Session Lifecycle
+
+```
+Start Session → Send Messages (sync or stream) → End Session
+                     ↓
+              Submit Feedback (optional)
+```
+
+- **Synchronous**: Full response in one HTTP response
+- **Streaming**: SSE events — `ProgressIndicator` → `TextChunk` → `Inform` → `EndOfTurn`
+- **End session**: `DELETE /sessions/{SESSION_ID}`
+- **Feedback**: `POST /sessions/{SESSION_ID}/feedback` with `feedbackId` from Inform message
+
+Full endpoint reference in [references/api-reference.md](references/api-reference.md).
+
+## Agent Variables
+
+Pass context and custom variables on session start or with messages:
+
+```json
+{
+  "variables": [
+    { "name": "$Context.EndUserLanguage", "value": "en_US" },
+    { "name": "team_descriptor", "value": "Sales West" }
+  ]
+}
+```
+
+Key rules:
+- Context variables (`$Context.*`) are read-only after session start (except `EndUserLanguage`)
+- Custom field variables: omit `__c` suffix (`Conversation_Key__c` → `$Context.Conversation_Key`)
+- Must check "Allow value to be set by API" in Builder; `visibility: external` in metadata
+
+Full variable reference in [references/api-reference.md](references/api-reference.md#agent-variables).
+
+## Token Caching (Next.js)
+
+HMR resets module-scoped variables. Use `globalThis` to survive reloads:
+
+```typescript
+const g = globalThis as typeof globalThis & {
+  __sfToken?: { token: string; expiresAt: number };
+};
+if (!g.__sfToken) g.__sfToken = { token: '', expiresAt: 0 };
+```
+
+- Never retry on rate limit
+- Dedup concurrent requests with a shared Promise
+- Expire tokens 60 seconds early
+
+Full caching patterns in [references/auth-setup.md](references/auth-setup.md#token-caching).
+
+## React Strict Mode
+
+React 18 dev mode double-mounts. Use `AbortController`, not `useRef` guards:
+
+```typescript
+useEffect(() => {
+  const controller = new AbortController();
+  fetch('/api/session', { method: 'POST', signal: controller.signal })
+    .then(r => r.json())
+    .then(data => setSessionId(data.sessionId))
+    .catch(err => {
+      if (err.name === 'AbortError') return;
+    });
+  return () => controller.abort();
+}, []);
+```
+
+## Quick Error Reference
+
+| Error | Fix |
+|-------|-----|
+| `Maximum Logins Exceeded` | Change Run As to admin/Integration User |
+| `login rate exceeded` | Wait 15–30 min; implement globalThis caching |
+| 404 `URL No Longer Exists` | Use `api.salesforce.com`, not My Domain |
+| `Missing required creator property 'sequenceId'` | Move sequenceId inside `message` object |
+| `Bad force-config endpoint` | `.trim()` all env vars |
+| No text in response | Use `msg.message`, not `msg.text` |
+| Session stuck "Connecting..." | Use AbortController pattern (Strict Mode) |
+| `EngineConfigLookupException` | Use My Domain URL, not Lightning URL |
+
+Full diagnostic checklist in [references/troubleshooting.md](references/troubleshooting.md).
+
+## Getting the Agent ID
+
+**Legacy Builder**: 18-char ID from URL in Setup → Agentforce Agents.
+
+**New Builder**: Query `SELECT Id FROM BotDefinition WHERE DeveloperName = 'Agent_Name'`.
+
+See [references/api-reference.md](references/api-reference.md#getting-the-agent-id) for the full lookup flow and the official Salesforce doc link.
+
+## Deep References
+
+| Topic | File |
+|-------|------|
+| Full API endpoints, payloads, variables, citations | [api-reference.md](references/api-reference.md) |
+| OAuth setup, ECA creation, token caching patterns | [auth-setup.md](references/auth-setup.md) |
+| Error codes, diagnostics, common integration bugs | [troubleshooting.md](references/troubleshooting.md) |
+| iOS, Android, React Native Mobile SDKs | [mobile-sdk.md](references/mobile-sdk.md) |
+| Testing API, Agentforce DX testing, CI/CD | [testing-api.md](references/testing-api.md) |
+| All Agentforce tools, SDKs, and builder comparison | [ecosystem.md](references/ecosystem.md) |

--- a/skills/sf-agentforce-agent-api/references/api-reference.md
+++ b/skills/sf-agentforce-agent-api/references/api-reference.md
@@ -1,0 +1,260 @@
+# Agent API Reference
+
+Complete endpoint reference for the Agentforce Agent API.
+
+> Official docs: [Agent API Reference](https://developer.salesforce.com/docs/ai/agentforce/references/agent-api?meta=summary)
+> Postman collection: [Agent API Postman](https://www.postman.com/salesforce-developers/salesforce-developers/collection/gwv9bjy/agent-api)
+
+## Base URL
+
+```
+https://api.salesforce.com/einstein/ai-agent/v1
+```
+
+Your My Domain goes in the request body as `instanceConfig.endpoint`, **not** in the URL.
+
+---
+
+## Endpoints
+
+### Start Session
+
+```
+POST /agents/{AGENT_ID}/sessions
+Content-Type: application/json
+Authorization: Bearer {ACCESS_TOKEN}
+```
+
+```json
+{
+  "externalSessionKey": "<random-uuid>",
+  "instanceConfig": {
+    "endpoint": "https://{MY_DOMAIN}"
+  },
+  "streamingCapabilities": {
+    "chunkTypes": ["Text"]
+  },
+  "bypassUser": true
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `externalSessionKey` | string (UUID) | Client-generated key for tracing in event logs |
+| `instanceConfig.endpoint` | string | Your My Domain URL (e.g. `https://myorg.my.salesforce.com`) |
+| `streamingCapabilities.chunkTypes` | string[] | Chunk types for streaming. Use `["Text"]` |
+| `bypassUser` | boolean | `true` = use agent-assigned user; `false` = use token user |
+
+**Response** (HTTP 200):
+```json
+{
+  "sessionId": "abc123...",
+  "_links": {
+    "messages": "/sessions/abc123.../messages",
+    "stream": "/sessions/abc123.../messages/stream",
+    "end": "/sessions/abc123..."
+  }
+}
+```
+
+### Send Synchronous Message
+
+```
+POST /sessions/{SESSION_ID}/messages
+Content-Type: application/json
+Authorization: Bearer {ACCESS_TOKEN}
+```
+
+```json
+{
+  "message": {
+    "type": "Text",
+    "text": "Hello, agent!",
+    "sequenceId": 1
+  }
+}
+```
+
+**Critical**: `sequenceId` goes **inside** the `message` object. Increment for each message in the session.
+
+**Response** (HTTP 200):
+```json
+{
+  "messages": [
+    {
+      "type": "Inform",
+      "message": "The response text is here",
+      "id": "msg-id",
+      "feedbackId": "feedback-id",
+      "isContentSafe": true,
+      "citedReferences": []
+    }
+  ]
+}
+```
+
+Response text is in `messages[].message`, **not** `messages[].text`.
+
+### Send Streaming Message
+
+```
+POST /sessions/{SESSION_ID}/messages/stream
+Content-Type: application/json
+Accept: text/event-stream
+Authorization: Bearer {ACCESS_TOKEN}
+```
+
+Same body as synchronous. The `Accept: text/event-stream` header triggers SSE.
+
+**SSE Event Types** (in order):
+
+| Event | Description |
+|-------|-------------|
+| `ProgressIndicator` | Response is being generated |
+| `TextChunk` | Incremental text fragment |
+| `Inform` | Complete final message with `citedReferences` |
+| `EndOfTurn` | Response is complete |
+| `ValidationFailureChunk` | Trust layer validation failed — discard prior chunks, render only new content |
+
+### End Session
+
+```
+DELETE /sessions/{SESSION_ID}
+Authorization: Bearer {ACCESS_TOKEN}
+```
+
+Returns HTTP 200 on success.
+
+### Submit Feedback
+
+```
+POST /sessions/{SESSION_ID}/feedback
+Content-Type: application/json
+Authorization: Bearer {ACCESS_TOKEN}
+```
+
+```json
+{
+  "feedbackId": "feedback-id-from-inform-message",
+  "feedback": "GOOD"
+}
+```
+
+`feedback` values: `"GOOD"` or `"BAD"`. Stored in Data 360.
+
+Returns HTTP 201 on success.
+
+---
+
+## Agent Variables
+
+Pass context and custom variables when starting a session or sending messages.
+
+```json
+{
+  "message": {
+    "type": "Text",
+    "text": "Check my records",
+    "sequenceId": 2
+  },
+  "variables": [
+    {
+      "name": "$Context.EndUserLanguage",
+      "value": "en_US"
+    },
+    {
+      "name": "team_descriptor",
+      "value": "Sales West"
+    },
+    {
+      "name": "troubleshootingSteps",
+      "value": "Rebooted, cleared cache"
+    }
+  ]
+}
+```
+
+### Variable Rules
+
+| Rule | Detail |
+|------|--------|
+| Context variables (`$Context.*`) | Read-only after session start, except `$Context.EndUserLanguage` |
+| Custom field variables | Omit `__c` suffix (e.g. `Conversation_Key__c` → `$Context.Conversation_Key`) |
+| Editable variables | Can be modified during send message calls |
+| Visibility | Must have `visibility: external` in metadata to be API-settable |
+| Builder setting | "Allow value to be set by API" must be checked |
+
+### Variable Metadata Fields
+
+Configure via `ConversationVariable` (in BotVersion) or `ConversationContextVariable` (in Bot).
+
+| Field | Description |
+|-------|-------------|
+| `dataType` | Text, Number, Boolean, Object, Date, DateTime, Currency, Id |
+| `description` | Used by the Agentforce planner service |
+| `developerName` | Unique name (letter start, no spaces, no trailing/consecutive underscores) |
+| `includeInPrompt` | Whether included in LLM prompt. Don't change for Id/EndUserId/EndUserLanguage |
+| `label` | Human-readable UI label |
+| `visibility` | `internal` (action output only) or `external` (action output + API) |
+
+---
+
+## Cited References
+
+Inform messages may include `citedReferences`:
+
+```json
+{
+  "type": "Inform",
+  "message": "According to our policy...",
+  "citedReferences": [
+    {
+      "title": "Policy Document",
+      "url": "https://...",
+      "inlineMetadata": {
+        "startIndex": 13,
+        "endIndex": 23
+      }
+    }
+  ]
+}
+```
+
+Citations can be end-of-message sources or inline (tied to specific text ranges via `inlineMetadata`).
+
+---
+
+## Getting the Agent ID
+
+The method depends on which builder created the agent:
+
+> Official docs: [Get the Agent ID for an Agent](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-api-agent-id.html)
+
+### What to look up
+
+- **Agent API name**: usually the agent's **DeveloperName**
+- **Agent ID**: the 18-character `Id` value used in the API URL
+
+### Legacy Agentforce Builder
+1. Setup → Agentforce Agents → select agent
+2. Copy the 18-character ID from the URL
+3. Example: `https://mydomain.salesforce-setup.com/.../0XxSB000000IPCr0AO/edit` → `0XxSB000000IPCr0AO`
+4. The URL ending is the **agent ID**
+
+### New Agentforce Builder
+Query the `BotDefinition` standard object using the agent's **DeveloperName**:
+
+```sql
+SELECT Id FROM BotDefinition WHERE DeveloperName = 'Your_Agent_Name'
+```
+
+The `DeveloperName` is the API name, and the `Id` field in the query result is the agent ID.
+
+---
+
+## Constraints
+
+- **Not supported** for agents of type "Agentforce (Default)"
+- **120-second timeout** per API call — HTTP 500 on timeout
+- Impacts credit consumption per [Generative AI Usage and Billing](https://help.salesforce.com/s/articleView?id=ai.generative_ai_usage_billing.htm)
+- Use My Domain URL (`myorg.my.salesforce.com`), **not** Lightning URL (`myorg.lightning.force.com`)

--- a/skills/sf-agentforce-agent-api/references/auth-setup.md
+++ b/skills/sf-agentforce-agent-api/references/auth-setup.md
@@ -1,0 +1,148 @@
+# Authentication & External Client App Setup
+
+Complete guide for OAuth Client Credentials flow with the Agentforce Agent API.
+
+> Official docs: [Get Started with Agent API](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-api-get-started.html)
+
+## Prerequisites
+
+- Agentforce enabled org with at least one activated agent
+- A user with API login access (admin or Integration User)
+
+---
+
+## Step 1: Create External Client App (ECA)
+
+1. Setup → Quick Find → "External Client App" → **External Client Apps Manager**
+2. **New External Client App** → provide name and contact email
+3. **Enable OAuth** with these scopes:
+   - `api` — Manage user data via APIs
+   - `refresh_token, offline_access` — Perform requests at any time
+   - `chatbot_api` — Access chatbot services
+   - `sfap_api` — Access the Salesforce API Platform
+4. Check these OAuth settings:
+   - **Enable Client Credentials Flow**
+   - **Issue JWT-based access tokens for named users**
+5. **Uncheck** these:
+   - Require secret for Web Server Flow
+   - Require secret for Refresh Token Flow
+   - Require PKCE for Supported Authorization Flows
+6. Save and create
+
+## Step 2: Configure Policy
+
+1. App settings → **Policy** tab → **Edit**
+2. Under "OAuth Flows and External Client App Enhancements":
+   - Check **Enable Client Credentials Flow**
+   - Set **Run As (Username)** to a user with API login access
+3. Save
+
+### Run As User — Critical Gotcha
+
+The Run As user **must** have a full Salesforce license with API login capability.
+
+**Do NOT use**:
+- Einstein Agent service users (`serviceagentagentforce...@example.com`) — restricted licenses, will return `invalid_grant` / `Maximum Logins Exceeded`
+- Users without API permissions
+
+**Use instead**:
+- Full Salesforce admin user (dev/testing)
+- Salesforce Integration User (production)
+
+## Step 3: Obtain Credentials
+
+1. App settings → **Settings** tab
+2. Expand **OAuth Settings**
+3. Click **Consumer Key and Secret**
+4. Copy both values
+
+---
+
+## Token Request
+
+```
+POST https://{MY_DOMAIN}/services/oauth2/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials&client_id={CONSUMER_KEY}&client_secret={CONSUMER_SECRET}
+```
+
+**Response:**
+```json
+{
+  "access_token": "00D...",
+  "instance_url": "https://myorg.my.salesforce.com",
+  "id": "https://login.salesforce.com/id/00D.../005...",
+  "token_type": "Bearer",
+  "issued_at": "1234567890",
+  "signature": "..."
+}
+```
+
+Use the `access_token` value in the `Authorization: Bearer` header for all Agent API calls.
+
+---
+
+## Token Caching
+
+### Why It Matters
+
+Salesforce enforces a **3,600 logins per user per hour** rolling rate limit. Exceeding it returns `login rate exceeded` and you must wait 15–30 minutes.
+
+### Next.js / HMR Gotcha
+
+In dev mode, Hot Module Replacement resets module-scoped variables on every file save. A naive token cache in module scope triggers a fresh OAuth request each save.
+
+**Fix — use `globalThis`:**
+
+```typescript
+const g = globalThis as typeof globalThis & {
+  __sfToken?: { token: string; expiresAt: number };
+};
+if (!g.__sfToken) g.__sfToken = { token: '', expiresAt: 0 };
+```
+
+### Caching Rules
+
+1. **Never retry on rate limit** — retrying burns more quota
+2. **Dedup concurrent requests** — share a single in-flight Promise:
+   ```typescript
+   let tokenPromise: Promise<string> | null = null;
+   async function getToken() {
+     if (g.__sfToken && Date.now() < g.__sfToken.expiresAt) {
+       return g.__sfToken.token;
+     }
+     if (!tokenPromise) {
+       tokenPromise = fetchNewToken().finally(() => { tokenPromise = null; });
+     }
+     return tokenPromise;
+   }
+   ```
+3. **Expire early** — subtract 60 seconds from the token's actual expiry
+4. **Trim env vars** — hosting platforms can add trailing `\n`:
+   ```typescript
+   const domain = process.env.SALESFORCE_MY_DOMAIN?.trim();
+   ```
+
+---
+
+## Environment Variables
+
+```env
+SALESFORCE_MY_DOMAIN=your-org.my.salesforce.com
+SALESFORCE_CONSUMER_KEY=3MVG9...
+SALESFORCE_CONSUMER_SECRET=ABC123...
+SALESFORCE_AGENT_ID=0XxHu000000XXXXKXX
+```
+
+Always normalize the domain:
+
+```typescript
+const endpoint = myDomain.startsWith('https://') ? myDomain : `https://${myDomain}`;
+```
+
+---
+
+## Alternative Auth Flows
+
+The Client Credentials flow is the most common for server-to-server Agent API integration. Other supported flows include any that produce a JWT-based access token. See [JWT-Based Access Tokens](https://help.salesforce.com/s/articleView?id=xcloud.jwt_access_tokens.htm) for alternatives.

--- a/skills/sf-agentforce-agent-api/references/ecosystem.md
+++ b/skills/sf-agentforce-agent-api/references/ecosystem.md
@@ -1,0 +1,57 @@
+# Agentforce Developer Ecosystem
+
+Quick-reference map of all Agentforce APIs, SDKs, and developer tools.
+
+> Official docs: [Get Started with Agentforce APIs and SDKs](https://developer.salesforce.com/docs/ai/agentforce/guide/get-started-agents.html)
+
+## Tools at a Glance
+
+| Tool | What It Does | Access |
+|------|-------------|--------|
+| [Agent API](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-api-get-started.html) | Chat with agents via REST — sessions, messages, streaming | REST API |
+| [Agent Script](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-script.html) | Build agents with natural language + programmatic expressions | Agentforce Builder |
+| [Agentforce DX](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-dx.html) | Pro-code CLI/VS Code tools for agents | SF CLI |
+| [Python SDK](https://github.com/salesforce/agent-sdk/tree/main) | Programmatic agent creation and management | Python |
+| [Testing API](https://developer.salesforce.com/docs/ai/agentforce/guide/testing-api-get-started.html) | Automated test evaluation at scale | REST/Metadata API |
+| [Mobile SDK](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk.html) | Native agent UI for iOS, Android, React Native | SDK |
+| [Enhanced Chat v2](https://developer.salesforce.com/docs/ai/agentforce/guide/get-started-enhanced-chat.html) | Web chat for Service Cloud | JavaScript |
+| [In-App Chat SDK](https://developer.salesforce.com/docs/service/messaging-in-app/guide/introduction.html) | Mobile chat for Service Cloud | SDK |
+
+## Build vs Test vs Use
+
+| Tool | Build | Test | Use |
+|------|-------|------|-----|
+| Agent Script | Yes | | |
+| Agentforce DX | Yes | Yes | Yes (preview) |
+| Python SDK | Yes | | |
+| Testing API | | Yes | |
+| Agent API | | | Yes |
+| Mobile SDK | | | Yes |
+| Enhanced Chat v2 | | | Yes |
+| In-App Chat SDK | | | Yes |
+
+## Agent Builders
+
+Salesforce has two agent builders:
+
+**New Agentforce Builder** (Canvas/Script view):
+- Access: App Launcher → Agentforce Studio
+- Features: AI assistance, Agent Script support, configurable canvas
+- Agent ID: Query `BotDefinition` via SOQL
+
+**Legacy Agentforce Builder** (visual topic editor):
+- Access: Setup → Agentforce Agents
+- Agent ID: 18-char ID from URL
+
+## Building Actions
+
+Actions are the building blocks for agent capabilities:
+- [Build and Enhance Agentforce Actions](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-actions.html)
+- Call agents from Flows or Apex via invocable actions
+
+## Learning Resources
+
+- [Trailhead: Agents and Agentforce Basics](https://trailhead.salesforce.com/)
+- [Salesforce Help: Agentforce Agents](https://help.salesforce.com/s/articleView?id=ai.copilot_intro.htm)
+- [YouTube: Integrate Agentforce with Microsoft Teams](https://www.youtube.com/watch?v=cbIOq_rQang)
+- [Postman Collection](https://www.postman.com/salesforce-developers/salesforce-developers/collection/gwv9bjy/agent-api)

--- a/skills/sf-agentforce-agent-api/references/mobile-sdk.md
+++ b/skills/sf-agentforce-agent-api/references/mobile-sdk.md
@@ -1,0 +1,194 @@
+# Agentforce Mobile SDK & Web Chat Reference
+
+Integration guides for embedding Agentforce agents in native mobile apps, React Native, and web chat.
+
+> Official docs: [Agentforce Mobile SDK](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk.html)
+
+## Overview
+
+The Agentforce Mobile SDK provides native UI components for iOS, Android, and React Native to embed agent conversations in mobile apps. It supports two agent modes:
+
+| Mode | Auth | Use Case |
+|------|------|----------|
+| **Service Agent** | None (anonymous) | Customer-facing support |
+| **Employee Agent** | OAuth via Salesforce Mobile SDK | Internal/authenticated use |
+
+---
+
+## Platform SDKs
+
+### iOS
+- Package: [AgentforceMobileSDK-iOS](https://github.com/salesforce/AgentforceMobileSDK-iOS) (CocoaPods)
+- Guide: [iOS Integration Guide](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-ios-integration-overview.html)
+- Quick Start: [iOS Quick Start](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-ios-quick-start.html)
+
+### Android
+- Package: [AgentforceMobileSDK-Android](https://github.com/salesforce/AgentforceMobileSDK-Android) (Maven)
+- Guide: [Android Integration Guide](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-android-integration-overview.html)
+- Quick Start: [Android Quick Start](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-android-quick-start.html)
+
+### React Native
+- Bridge to native iOS/Android SDKs with JavaScript API
+- Guide: [React Native Integration Guide](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-react-native-integration-overview.html)
+- Quick Start: [React Native Quick Start](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-react-native-quick-start.html)
+
+---
+
+## Org Values by Agent Type
+
+### Service Agent
+Gather from Salesforce Setup:
+
+| Value | Location |
+|-------|----------|
+| Service API URL | Setup → Embedded Service Deployments → your deployment → Settings |
+| Organization ID | Setup → Company Information |
+| ES Developer Name | Setup → Embedded Service Deployments → Developer Name |
+
+### Employee Agent
+Gather from Salesforce Setup:
+
+| Value | Location |
+|-------|----------|
+| Agent ID | Agent Details page URL (18-char ID at end) |
+| User ID | User profile page. See [Find User ID](https://help.salesforce.com/s/articleView?id=000381643&type=1) |
+| Salesforce Domain | Setup → My Domain → Current My Domain URL |
+
+---
+
+## React Native Quick Start (Service Agent)
+
+### Prerequisites
+- Salesforce org with Agentforce enabled
+- Service Agent configured (Setup → Embedded Service Deployments)
+- Service API URL, Organization ID, and ES Developer Name from org
+
+### 1. Install
+
+```bash
+npm install @salesforce/react-native-agentforce
+```
+
+### 2. iOS Setup
+
+In `ios/Podfile`, add the bridge pod then install:
+
+```bash
+cd ios && pod install
+```
+
+### 3. Android Setup
+
+In `android/app/build.gradle`, add Maven repositories for the SDK.
+
+Register the native package in `MainApplication.kt`.
+
+Add the conversation activity to `AndroidManifest.xml`.
+
+### 4. Minimal Service Agent Component
+
+```tsx
+import { AgentforceSDK } from '@salesforce/react-native-agentforce';
+
+function ChatButton() {
+  const startChat = async () => {
+    // Configure with org values
+    AgentforceSDK.configure({
+      serviceApiUrl: 'YOUR_SERVICE_API_URL',
+      organizationId: 'YOUR_ORG_ID',
+      esDeveloperName: 'YOUR_ES_DEVELOPER_NAME',
+    });
+    // Launch full-screen conversation UI
+    AgentforceSDK.startConversation();
+  };
+
+  return <Button title="Chat with Agent" onPress={startChat} />;
+}
+```
+
+When tapped: SDK configures with org details → full-screen conversation UI → user chats with agent.
+
+### React Native Features
+
+| Feature | Description |
+|---------|-------------|
+| Feature Flags | Toggle multi-agent, voice, camera, PDF upload |
+| Hidden Prechat Fields | Pre-populate form data for Service Agent sessions |
+| Additional Context | Pass contextual variables to personalize responses |
+| Delegates | Logger, navigation, and custom view provider callbacks |
+
+### Key React Native Topics
+- [Requirements](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-react-native-requirements.html)
+- [Installation](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-react-native-install.html)
+- [Configuration](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-react-native-integration.html)
+- [Conversations](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-react-native-conversations.html)
+- [Delegates](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-react-native-delegates.html)
+- [Employee Auth](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-react-native-employee-auth.html)
+- [Limitations](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-react-native-limitations.html)
+- [Troubleshooting](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-sdk-react-native-troubleshooting.html)
+
+---
+
+## Enhanced Chat v2 (Web)
+
+> Official docs: [Get Started with Enhanced Chat v2](https://developer.salesforce.com/docs/ai/agentforce/guide/get-started-enhanced-chat.html)
+
+Enhanced Chat v2 is a customer interface for deploying Service agents to external web chat channels.
+
+**Key features:**
+- Customizable UI via [Lightning Types](https://developer.salesforce.com/docs/ai/agentforce/guide/enhanced-chat-lightning-types.html)
+- Context passing via `utilAPI.setSessionContext()`
+- Human-in-the-loop escalation from agent to human rep
+- Two display modes: floating (default) and inline
+
+**Not the same as** Enhanced Web Chat (the predecessor).
+
+### Setup
+
+1. Setup → Embedded Service Deployments → select deployment
+2. Click **Code Snippet**
+3. Add snippet to your web page
+
+### Inline Mode
+
+Renders the chat client directly within a `<div>` instead of a floating button. The chat fills the target element entirely.
+
+```javascript
+// Enable inline mode
+embeddedservice_bootstrap.settings.displayMode = 'inline';
+
+// Specify target container
+embeddedservice_bootstrap.settings.targetElement = document.getElementById('chat-container');
+```
+
+**Configuration rules:**
+- `displayMode = 'inline'` requires a custom `targetElement` (not `document.body`)
+- If `targetElement` is set but `displayMode` is not `'inline'`, the chat button floats within that container
+- Header can be toggled on/off in inline mode
+
+**Console warnings:**
+| Warning | Fix |
+|---------|-----|
+| `displayMode is set to "inline" but targetElement is using the default` | Set `targetElement` to a custom container |
+| `targetElement is set to a custom element but displayMode is not set to "inline"` | Either set `displayMode = 'inline'` or remove custom `targetElement` |
+
+### Context Events
+
+Pass context to the agent via the `setSessionContext` method on `utilAPI`:
+
+```javascript
+embeddedservice_bootstrap.utilAPI.setSessionContext({
+  key: 'value'
+});
+```
+
+See the [Enhanced Chat Developer Guide](https://developer.salesforce.com/docs/ai/agentforce/guide/get-started-enhanced-chat.html) and [Enhanced Chat Reference](https://developer.salesforce.com/docs/ai/agentforce/references/enhanced-chat) for full API.
+
+---
+
+## Enhanced In-App Chat SDK
+
+For Service Cloud in-app mobile chat:
+- [Documentation](https://developer.salesforce.com/docs/service/messaging-in-app/guide/introduction.html)
+- Customizable messaging inside native apps
+- Seamless escalation with full conversation context

--- a/skills/sf-agentforce-agent-api/references/testing-api.md
+++ b/skills/sf-agentforce-agent-api/references/testing-api.md
@@ -1,0 +1,324 @@
+# Agentforce Testing API & Agent Testing
+
+Programmatic test automation for Agentforce agents.
+
+> Official docs: [Testing API Developer Guide](https://developer.salesforce.com/docs/ai/agentforce/guide/testing-api.html)
+
+## Testing Methods
+
+| Method | Access | Format | Custom Evaluations | Best For |
+|--------|--------|--------|--------------------|----------|
+| [Testing Center](https://help.salesforce.com/s/articleView?id=ai.agent_testing_center.htm) | UI | CSV | No | Non-developers, quick manual tests |
+| [Agentforce DX](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-dx-test.html) | CLI | YAML | Yes | Pro-code dev workflows |
+| [Testing API](https://developer.salesforce.com/docs/ai/agentforce/guide/testing-api-build-tests.html) | Code | XML | Yes | CI/CD pipelines, automation |
+
+---
+
+## Prerequisites & Limits
+
+- Agentforce enabled with at least one active agent
+- **Sandbox only** — agent testing is not available in production
+- Running tests consumes Einstein Requests credits (and possibly Data 360 credits)
+- Running tests can modify data in your org
+- Max **10 concurrent** `IN-PROGRESS` runs
+- Max **1,000 test cases** per `AiEvaluationDefinition`
+- Test results may change over time due to testing service improvements
+
+---
+
+## Workflow: Create → Deploy → Run → Analyze
+
+### 1. Create Tests
+
+**Metadata API (XML)** — define `AiEvaluationDefinition`:
+- [Build Tests in Metadata API](https://developer.salesforce.com/docs/ai/agentforce/guide/testing-api-build-tests.html)
+
+**Agentforce DX (YAML)** — generate test specs:
+- [Generate a Test Spec](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-dx-test-spec.html)
+
+### 2. Deploy Tests
+
+```bash
+# Metadata API via CLI
+sf project deploy start -m AiEvaluationDefinition:YourTestName
+
+# Or via VS Code Command Palette
+SFDX: Deploy This Source to Org
+```
+
+Agentforce DX: [Create an Agent Test](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-dx-test-create.html)
+
+### 3. Run Tests
+
+**Agentforce DX:**
+```bash
+sf agent test run --agent-api-name Your_Agent_Name --target-org your-sandbox
+```
+
+**Connect API:**
+```bash
+# Start test
+sf api request rest /services/data/v63.0/einstein/ai-evaluations/runs \
+  --method POST --body '{"aiEvaluationDefinitionName":"YourTestName"}'
+
+# Poll status (replace {runId})
+sf api request rest /services/data/v63.0/einstein/ai-evaluations/runs/{runId}
+
+# Get results
+sf api request rest /services/data/v63.0/einstein/ai-evaluations/runs/{runId}/results
+```
+
+### 4. Analyze Results
+
+See [Use Test Results to Improve Your Agent](https://developer.salesforce.com/docs/ai/agentforce/guide/testing-api-use-results.html).
+
+---
+
+## Building Tests with Metadata API
+
+The `AiEvaluationDefinition` metadata type contains test cases. Each test case has inputs (utterance + optional context) and expectations.
+
+### Test Case Inputs
+
+| Input Type | Description |
+|------------|-------------|
+| Utterance | The primary user message to send to the agent |
+| Context variables | `$Context.*` variables for scenario simulation. Immutable after session start except `EndUserLanguage` |
+| Conversation history | Prior messages for multi-turn testing (role, text, topic, index) |
+
+### Conversation History (Multi-Turn)
+
+Add `conversationHistory` to inputs for multi-turn context:
+
+```xml
+<inputs>
+  <utterance>What about the second item?</utterance>
+  <conversationHistory>
+    <role>user</role>
+    <messageText>Show me my open cases</messageText>
+    <messageIndex>0</messageIndex>
+  </conversationHistory>
+  <conversationHistory>
+    <role>agent</role>
+    <messageText>Here are your 3 open cases...</messageText>
+    <topicName>CaseManagement</topicName>
+    <messageIndex>1</messageIndex>
+  </conversationHistory>
+</inputs>
+```
+
+### Sample Test Definition (XML)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<AiEvaluationDefinition xmlns="http://soap.sforce.com/2006/04/metadata">
+  <name>MyAgentTests</name>
+  <subjectName>Your_Agent_Name</subjectName>
+  <subjectType>AGENT</subjectType>
+  <testCases>
+    <testCase>
+      <number>1</number>
+      <inputs>
+        <utterance>Summarize the Global Media account</utterance>
+      </inputs>
+      <expectations>
+        <expectation>
+          <name>topic_sequence_match</name>
+          <expectedValue>OOTBSingleRecordSummary</expectedValue>
+        </expectation>
+        <expectation>
+          <name>action_sequence_match</name>
+          <expectedValue>IdentifyRecordByName</expectedValue>
+        </expectation>
+        <expectation>
+          <name>bot_response_rating</name>
+          <expectedValue>Contains account summary</expectedValue>
+        </expectation>
+        <expectation>
+          <name>conciseness</name>
+        </expectation>
+      </expectations>
+    </testCase>
+  </testCases>
+</AiEvaluationDefinition>
+```
+
+---
+
+## Expectation Types (Standard)
+
+| Expectation Name | What It Tests | `expectedValue` Required | `metricScore` |
+|-----------------|---------------|--------------------------|---------------|
+| `topic_sequence_match` | Agent used the expected topic | Yes — topic name | PASS / FAILED |
+| `action_sequence_match` | Agent used the expected action(s) | Yes — action name | PASS / FAILED |
+| `bot_response_rating` | Semantic comparison of response vs expected (meaning, not exact text) | Yes — expected response text | PASS / FAILED |
+| `coherence` | Response is understandable, no grammar errors | No | PASS / FAILED |
+| `completeness` | Response includes all essential information | No | PASS / FAILED |
+| `conciseness` | Response is brief but comprehensive | No | PASS / FAILED |
+| `output_latency_milliseconds` | Latency from request to response (ms) | No | Numeric value |
+| `instruction_adherence` | How well response follows topic instructions | No | HIGH / LOW / UNCERTAIN |
+
+### Reading Failed Results
+
+- **Topic fail**: Compare `expectedValue` (in test def) vs actual topic the agent routed to
+- **Action fail**: Compare `expectedValue` vs actual action sequence
+- **Response fail**: Check if the meaning diverged significantly
+- **Instruction adherence**: `generatedData` = raw LLM response; `actualValue` = final agent response
+
+Use the Agent Builder conversation preview to test utterances interactively and fine-tune instructions, actions, or topics.
+
+---
+
+## Custom Evaluation Criteria
+
+> [Custom Evaluation Criteria docs](https://developer.salesforce.com/docs/ai/agentforce/guide/testing-api-custom-evaluation-criteria.html)
+
+Available in Testing API and Agentforce DX only (not Testing Center). Test for specific strings or numbers in agent responses.
+
+### Custom Evaluation Types
+
+| Type | API Name | Use Case |
+|------|----------|----------|
+| String comparison | `string_comparison` | Check for specific text in responses |
+| Numeric comparison | `numeric_comparison` | Check latency, counts, numeric outputs |
+
+### String Comparison Operators
+
+| Operator | Behavior | Case Sensitive |
+|----------|----------|----------------|
+| `equals` | Exact match | Yes |
+| `contains` | Substring check | Yes |
+| `startswith` | Prefix check | Yes |
+| `endswith` | Suffix check | Yes |
+
+### Numeric Comparison Operators
+
+| Operator | Behavior |
+|----------|----------|
+| `equals` | `actual == expected` |
+| `greater_than` | `actual > expected` |
+| `greater_than_or_equal` | `actual >= expected` |
+| `less_than` | `actual < expected` |
+| `less_than_or_equal` | `actual <= expected` |
+
+### Custom Evaluation XML Structure
+
+Each parameter has `name`, `value`, and `isReference` fields:
+
+```xml
+<expectation>
+  <name>string_comparison</name>
+  <expectedValues>
+    <parameter>
+      <name>actual</name>
+      <value>$.actions[?(@.action=='namespace_actionName')].inputs.query</value>
+      <isReference>true</isReference>
+    </parameter>
+    <parameter>
+      <name>expected</name>
+      <value>John Smith</value>
+      <isReference>false</isReference>
+    </parameter>
+    <parameter>
+      <name>operator</name>
+      <value>contains</value>
+      <isReference>false</isReference>
+    </parameter>
+  </expectedValues>
+</expectation>
+```
+
+### JSONPath for `actual` Values
+
+The `actual` parameter uses JSONPath to reference data from `generatedData` in test results. `isReference` must be `true`.
+
+Common patterns:
+
+```
+# Action input
+$.actions[?(@.action=='namespace_actionName')].inputs.query
+
+# Action output
+$.actions[?(@.action=='namespace_actionName')].outputs.result
+
+# Additional context value (first item)
+$.actions[?(@.action=='namespace_actionName')].additionalContext[0].value
+```
+
+**Tip**: Use `sf agent test run --verbose` to see the generated JSON data and construct JSONPath expressions.
+
+Each parameter `value` field is limited to **100 characters**.
+
+---
+
+## Connect API Endpoints
+
+Auth setup is identical to Agent API — create an External Client App with Client Credentials flow. Required scopes: `chatter_api`, `api`, `web`, `refresh_token`/`offline_access`.
+
+| Endpoint | Method | Path |
+|----------|--------|------|
+| Start Test | POST | `/services/data/v63.0/einstein/ai-evaluations/runs` |
+| Get Test Status | GET | `/services/data/v63.0/einstein/ai-evaluations/runs/{runId}` |
+| Get Test Results | GET | `/services/data/v63.0/einstein/ai-evaluations/runs/{runId}/results` |
+
+### Start Test
+
+```bash
+curl -X POST "https://{INSTANCE}/services/data/v63.0/einstein/ai-evaluations/runs" \
+  -H "Authorization: Bearer {TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"aiEvaluationDefinitionName":"YourTestName"}'
+```
+
+Returns `runId` for polling.
+
+### Get Status (Poll)
+
+```bash
+curl "https://{INSTANCE}/services/data/v63.0/einstein/ai-evaluations/runs/{runId}" \
+  -H "Authorization: Bearer {TOKEN}"
+```
+
+Poll until status is no longer `IN-PROGRESS`.
+
+### Get Results
+
+```bash
+curl "https://{INSTANCE}/services/data/v63.0/einstein/ai-evaluations/runs/{runId}/results" \
+  -H "Authorization: Bearer {TOKEN}"
+```
+
+Results include `metricScore` per expectation and `errorMessage` for failures.
+
+---
+
+## Agentforce DX Testing Commands
+
+```bash
+# Generate a test spec (YAML)
+sf agent test spec generate
+
+# Create/deploy a test to org
+sf agent test create
+
+# Run tests
+sf agent test run --agent-api-name Agent_Name --target-org sandbox-alias
+
+# Run with verbose output (shows generatedData JSON)
+sf agent test run --verbose
+
+# Preview agent interactively (manual testing)
+sf agent preview
+```
+
+See [Test an Agent with Agentforce DX](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-dx-test.html) for full CLI reference.
+
+---
+
+## Related Metadata Types
+
+- [AiEvaluationDefinition](https://developer.salesforce.com/docs/ai/agentforce/references/testing-api-metadata)
+- [Bot](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_bot.htm)
+- [BotVersion](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_botversion.htm)
+- [BotTemplate](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_bottemplate.htm)
+- [Agentforce Metadata Types](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-metadata.html)

--- a/skills/sf-agentforce-agent-api/references/troubleshooting.md
+++ b/skills/sf-agentforce-agent-api/references/troubleshooting.md
@@ -1,0 +1,103 @@
+# Troubleshooting & Error Reference
+
+> Official docs: [Agent API Troubleshooting](https://developer.salesforce.com/docs/ai/agentforce/guide/agent-api-troubleshooting.html)
+
+## HTTP Error Codes
+
+### HTTP 400 — Bad Request
+
+| Error Message | Cause | Fix |
+|---------------|-------|-----|
+| `{VALUE} is not a valid agent ID` | Wrong agent ID in URL | Verify agent ID — see [api-reference.md](api-reference.md) "Getting the Agent ID" |
+| `Missing required creator property 'sequenceId'` | `sequenceId` placed at message root | Move `sequenceId` **inside** the `message` object |
+
+### HTTP 401 — Unauthorized
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `invalid_grant` | Service user as Run As, or bad credentials | Use admin/Integration User. Verify consumer key/secret |
+| `Maximum Logins Exceeded` | Einstein Agent service user | Change Run As to a full-license user |
+| `login rate exceeded` | Too many OAuth requests | Wait 15–30 min. Implement `globalThis` caching — see [auth-setup.md](auth-setup.md) |
+| Token expired | Token not refreshed | Implement token caching with early expiry |
+
+### HTTP 404 — Not Found
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `URL No Longer Exists` | My Domain used as API host | Use `api.salesforce.com/einstein/ai-agent/v1` as base URL |
+| Resource not found | Wrong session ID | Verify `sessionId` from start session response |
+
+### HTTP 500 — Server Error
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Unsupported Media Type` | Wrong Content-Type header | Use `Content-Type: application/json` |
+| `EngineConfigLookupException` | Wrong domain in endpoint | Use **My Domain** URL (`myorg.my.salesforce.com`), not Lightning URL |
+| `HttpServerErrorException` | Wrong agent ID | Verify agent ID per the correct builder method |
+| Timeout (120s) | Agent response took too long | Simplify agent logic; consider streaming endpoint |
+
+---
+
+## Common Integration Issues
+
+### No Text in Response
+
+**Symptom**: Parsing `msg.text` returns undefined.
+**Fix**: Response text is in `messages[].message`, not `messages[].text`.
+
+### Session Stuck on "Connecting..."
+
+**Symptom**: React app never shows agent response.
+**Cause**: `useRef` guard with React 18 Strict Mode double-mount.
+**Fix**: Use `AbortController` pattern:
+
+```typescript
+useEffect(() => {
+  const controller = new AbortController();
+  async function init() {
+    const res = await fetch('/api/session', {
+      method: 'POST',
+      signal: controller.signal,
+    });
+    const data = await res.json();
+    setSessionId(data.sessionId);
+  }
+  init().catch(err => {
+    if (err instanceof DOMException && err.name === 'AbortError') return;
+  });
+  return () => controller.abort();
+}, []);
+```
+
+### `Bad force-config endpoint`
+
+**Cause**: Trailing `\n` in environment variable (common on Vercel, Heroku, etc.).
+**Fix**: `.trim()` all env vars before use.
+
+### Streaming ValidationFailureChunk
+
+**Symptom**: Streaming response contains `ValidationFailureChunk` event.
+**Cause**: Agentforce trust layer rejected the response.
+**Fix**: Discard all previously rendered chunks. Display only new streamed content after the validation event.
+
+### Domain Confusion
+
+| URL Type | Example | Use For |
+|----------|---------|---------|
+| My Domain | `myorg.my.salesforce.com` | Token requests + `instanceConfig.endpoint` |
+| Lightning | `myorg.lightning.force.com` | **Never** — not valid for API |
+| Agent API | `api.salesforce.com` | All Agent API calls |
+
+---
+
+## Diagnostic Checklist
+
+When debugging Agent API integration:
+
+1. **Auth**: Is the token valid and not expired? Is the Run As user correct?
+2. **Endpoint**: Using `api.salesforce.com` for Agent API, My Domain for OAuth?
+3. **Agent ID**: Correct ID from the right builder? 18-character format?
+4. **Headers**: `Content-Type: application/json`? `Accept: text/event-stream` for streaming?
+5. **Body**: `sequenceId` inside `message` object? `instanceConfig.endpoint` set?
+6. **Env vars**: All trimmed? Domain normalized with `https://`?
+7. **Rate limits**: Token being cached? Not retrying on `login rate exceeded`?


### PR DESCRIPTION
## Summary
- Add `sf-agentforce-agent-api`, a focused skill for Agentforce API integration work.
- Cover Agent API auth and sessions, agent ID lookup, variables, token caching, Mobile SDKs, Enhanced Chat v2, and Testing API workflows.
- Update the repo README so the new skill is discoverable in the catalog.

Thanks for the strong foundation here, Jag. This may overlap a bit with the broader Agentforce skill, but this one gives the API-focused path a clearer, more specific entry point.