### PR TITLE
feat(agentscript/patterns): add Pattern 6 (description contracts) and multi-step workflow hardening

### DIFF
--- a/skills/sf-ai-agentscript/assets/patterns/README.md
+++ b/skills/sf-ai-agentscript/assets/patterns/README.md
@@ -33,6 +33,10 @@ What do you need?
 │   └─► Use: open-gate-routing.agent
 │       (3-variable state machine with LLM bypass)
 │
+├─► Multi-stage workflow with progress tracking?
+│   └─► Use: multi-step-workflow.agent
+│       (boolean flags, step guard, resume, rollback)
+│
 └─► None of the above?
     └─► Start with: ../getting-started/hello-world.agent
 ```
@@ -151,6 +155,7 @@ reasoning:
 | Fixed Value | `with x="value"` | Always use a constant |
 | Variable | `with x=@variables.y` | Use stored state |
 | Output | `with x=@outputs.y` | Chain from previous action |
+| Description Contract | description with rules | LLM normalizes/transforms value |
 
 ---
 
@@ -216,6 +221,46 @@ before_reasoning:
 
 ---
 
+### 7. [multi-step-workflow.agent](multi-step-workflow.agent)
+
+**Purpose**: Track progress through complex multi-stage processes using boolean flags and a step guard.
+
+**Use when**:
+- User onboarding with multiple required steps
+- Order/checkout or application submission flows
+- Any workflow where steps must happen in order
+- Resumable workflows (user can leave and return mid-flow)
+
+**Key syntax**:
+```agentscript
+variables:
+   step_1_done: mutable boolean = False
+   current_step: mutable number = 1
+
+reasoning:
+   instructions: ->
+      # Step guard — prevents mid-workflow re-routing
+      if @variables.current_step > 1:
+         | Continuing your setup...
+
+   actions:
+      do_step_1: @actions.create_account
+         with email=...
+         set @variables.step_1_done = @outputs.success
+         set @variables.current_step = 2
+         available when @variables.step_1_done == False
+```
+
+**Production Hardening**:
+| Variant | Purpose |
+|---------|---------|
+| Rollback | Let users redo an earlier step |
+| Post-completion immutability | `available when @variables.complete == False` on all mutations |
+| Resume detection | Offer to continue when user returns mid-workflow |
+| Show-then-accept compliance gate | Two flags to prove content was displayed before acceptance |
+
+---
+
 ## Pattern Combinations
 
 These patterns can be combined:
@@ -243,6 +288,7 @@ open-gate-routing + lifecycle-events
 | Input Bindings | +5 pts | Proper binding patterns |
 | System Overrides | +5 pts | Static system, dynamic topics |
 | Open Gate | +5 pts | 3-variable coordination |
+| Multi-Step Workflow | +5 pts | Step guard + boolean flags |
 
 ## Anti-Patterns to Avoid
 
@@ -254,3 +300,5 @@ open-gate-routing + lifecycle-events
 | Use lifecycle for one-time setup | Use if @variables.turn_count == 1 |
 | Missing EXIT_PROTOCOL in gate pattern | Always include gate reset topic |
 | Hardcoding gate topic name in open_gate | Use variable-driven routing |
+| No step guard in multi-step workflow | Add `if @variables.current_step > 1` guard |
+| Allowing steps out of order | Use `available when` on all step actions |

--- a/skills/sf-ai-agentscript/assets/patterns/advanced-input-bindings.agent
+++ b/skills/sf-ai-agentscript/assets/patterns/advanced-input-bindings.agent
@@ -78,6 +78,23 @@ topic order_processing:
 					description: "Whether notification was sent"
 			target: "flow://Send_Order_Notification"
 
+		# ★ Action with transformation contracts in parameter descriptions
+		save_contact:
+			description: "Save contact information to CRM"
+			inputs:
+				full_name: string
+					description: "Full name in Title Case. Convert 'john smith' to 'John Smith', 'JOHN SMITH' to 'John Smith'."
+				phone_number: string
+					description: "Phone in E.164 format: +[country][number]. '07700 123456' → '+447700123456'. '(202) 555-1234' → '+12025551234'. Always add country code if missing (default +44 UK). Remove all spaces, dashes, parentheses. Final format: '+' followed by digits only."
+				email: string
+					description: "Email in lowercase, whitespace trimmed. 'John.Doe@Example.COM  ' → 'john.doe@example.com'. Must contain '@' and a domain."
+				postal_code: string
+					description: "UK postcode uppercase with space. 'sw1a1aa' → 'SW1A 1AA'. 'SW1A1AA' → 'SW1A 1AA'."
+			outputs:
+				contact_id: string
+					description: "Created contact ID"
+			target: "flow://Save_Contact"
+
 	reasoning:
 		instructions: ->
 			| Help the customer process their order.
@@ -129,13 +146,30 @@ topic order_processing:
 				with amount=@variables.amount                   # From variable
 				with account_id="001INTERNAL00001"              # Fixed value
 
+			# ★ PATTERN 6: Description as Transformation Contract
+			# save_contact's descriptions contain normalization rules.
+			# Compare with process_order's generic descriptions above.
+			contract_binding: @actions.save_contact
+				with full_name=...
+				with phone_number=...
+				with email=...
+				with postal_code=...
+
 # ★ Insight: Binding Pattern Decision Tree
 #
 # Need the LLM to extract from conversation?     -> Use `...`
 # Value is always the same constant?             -> Use "value"
 # Value was captured in a previous step?         -> Use @variables.x
 # Value comes from another action's output?      -> Use @outputs.x (in callback)
+# Need the LLM to normalize/transform the value? -> Use description contract (Pattern 6)
 #
 # ★ Common Mistake: Using @outputs.x outside of a `run` callback
 # @outputs.x is only available inside the action's callback chain
 # Store important outputs in @variables for use elsewhere
+#
+# ★ Why Description Contracts Work (Pattern 6)
+#   The LLM reads parameter descriptions IMMEDIATELY before invocation —
+#   closer than topic instructions. This temporal proximity makes
+#   descriptions the most reliable place for normalization rules.
+#   Not platform-enforced; for critical validation pair with a
+#   server-side action (see critical-input-collection.agent).

--- a/skills/sf-ai-agentscript/assets/patterns/multi-step-workflow.agent
+++ b/skills/sf-ai-agentscript/assets/patterns/multi-step-workflow.agent
@@ -281,3 +281,76 @@ start_agent onboarding:
 # RESUME CAPABILITY:
 #   - Boolean flags persist across conversation turns
 #   - User can pick up where they left off
+#
+# ═══════════════════════════════════════════════════════════════════════════
+# ★ Production Hardening Variants
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# ROLLBACK:
+#   Let users redo earlier steps without restarting the whole workflow.
+#
+#   reset_to_step_2: @utils.setVariables
+#      description: "Let user redo profile info (clears steps 2-3)"
+#      with step_2_profile_completed = False
+#      with step_3_preferences_set = False
+#      with current_step = 2
+#      available when @variables.step_2_profile_completed == True
+#      available when @variables.onboarding_complete == False
+#
+# POST-COMPLETION IMMUTABILITY:
+#   Add `available when @variables.onboarding_complete == False` to
+#   EVERY mutation action. Once the workflow finalizes, the platform
+#   physically prevents all state changes — the LLM cannot override it.
+#
+# RESUME DETECTION:
+#   When users leave mid-workflow (FAQ, topic switch) and return,
+#   detect prior progress and offer to continue. Use a separate flag:
+#
+#   resume_prompted: mutable boolean = False
+#      description: "True after we've offered to resume"
+#
+#   # At the TOP of instructions, before step logic:
+#   if @variables.step_1_account_created == True and @variables.resume_prompted == False:
+#      | I see you already started. Name: {!@variables.user_name}
+#      | Would you like to continue or start over?
+#
+#   mark_resume_prompted: @utils.setVariables
+#      with resume_prompted = True
+#      available when @variables.resume_prompted == False
+#
+#   reset_workflow: @utils.setVariables
+#      with step_1_account_created = False
+#      with step_2_profile_completed = False
+#      with step_3_preferences_set = False
+#      with step_4_verification_done = False
+#      with resume_prompted = False
+#      with current_step = 1
+#      available when @variables.onboarding_complete == False
+#
+# SHOW-THEN-ACCEPT COMPLIANCE GATE:
+#   For legal/GDPR/age gates, use TWO flags so acceptance can't happen
+#   without the content being shown first:
+#
+#   disclaimer_shown: mutable boolean = False
+#   disclaimer_accepted: mutable boolean = False
+#
+#   mark_disclaimer_shown: @utils.setVariables
+#      with disclaimer_shown = True
+#      available when @variables.disclaimer_shown == False
+#
+#   accept_disclaimer: @utils.setVariables
+#      with disclaimer_accepted = True
+#      available when @variables.disclaimer_shown == True
+#      available when @variables.disclaimer_accepted == False
+#
+#   do_step_1: @actions.create_account
+#      ...
+#      available when @variables.disclaimer_accepted == True
+#
+#   Use two flags when you must PROVE content was displayed.
+#   Use one flag when simple confirmation suffices.
+#
+# NON-INTERACTIVE STAGES:
+#   Not every step needs user input. For data-processing chains
+#   (normalize → validate → enrich), the user provides input once
+#   at stage 1. Stages 2+ run on processed output without prompting.


### PR DESCRIPTION
## Summary

- **`advanced-input-bindings.agent`**: adds Pattern 6 — description-as-transformation-contract — with a `save_contact` example showing phone (E.164), email (lowercase), name (Title Case), and postcode normalization. Expands the decision tree to cover the normalization use case.
- **`multi-step-workflow.agent`**: adds a Production Hardening Variants section covering rollback, post-completion immutability, resume detection, show-then-accept compliance gates, and non-interactive stages. Also documents the Step Guard pattern (Feb 2026 community best practice).
- **`README.md`**: adds `multi-step-workflow` to the decision tree, patterns overview (§7), validation scoring table, and anti-patterns. Adds description contract row to the binding quick-reference table.

## Test plan

- [ ] Review `advanced-input-bindings.agent` — confirm Pattern 6 example is syntactically correct and description contracts are clearly explained
- [ ] Review `multi-step-workflow.agent` — confirm Production Hardening Variants are commented-out (non-breaking) and the Step Guard note is accurate
- [ ] Review `README.md` — confirm decision tree, overview §7, scoring table, and anti-patterns all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)