### PR TITLE
feat(sf-react): add Multi-Framework / Headless 360 React skill

### DIFF
--- a/skills/sf-react/CREDITS.md
+++ b/skills/sf-react/CREDITS.md
@@ -1,0 +1,17 @@
+# Credits
+
+## Content sources
+
+- **Recipe catalogue, patterns, and conventions**: [trailheadapps/multiframework-recipes](https://github.com/trailheadapps/multiframework-recipes) — the official Salesforce Multi-Framework / React-on-Agentforce-360 reference, maintained by the Salesforce Developer Relations team.
+- **Headless 360 launch context**: Salesforce TDX 2026 announcements (April 15 2026), and the [Salesforce Multi-Framework developer blog post](https://developer.salesforce.com/blogs/2026/04/build-with-react-run-on-salesforce-introducing-salesforce-multi-framework).
+- **Skill shape and conventions**: modeled on the existing `sf-lwc` skill in this repository.
+
+## Authoring
+
+- Drafted using a structured skill-authoring interview ("skill-forge") that closes Steve Kinney's nine universal skill gaps plus three extensions (description hygiene, verification, handoff). See https://stevekinney.com/writing/temporal-developer-skill for the gap framework.
+- Refined via iterative judge feedback against the same gap criteria (the "simmer" skill).
+- AI-assisted authoring is disclosed per this repository's CONTRIBUTING.md AI policy. The author personally reviewed and validated the content against the source recipes repo and the `check_draft.py` validator.
+
+## License
+
+MIT, matching the parent project.

--- a/skills/sf-react/README.md
+++ b/skills/sf-react/README.md
@@ -1,0 +1,35 @@
+# sf-react
+
+Salesforce skill for working with React on the **Multi-Framework** runtime — the new native-React layer of Headless 360 / the Agentforce 360 Platform, announced at TDX 2026 (April 15 2026).
+
+Helps an LLM agent ground its work in the official `trailheadapps/multiframework-recipes` patterns rather than freelancing against beta APIs.
+
+## What this skill does
+
+- Detects Multi-Framework projects via `uiBundles/`, `ui-bundle.json`, `.uibundle-meta.xml`, and `package.json` markers
+- Routes tasks to the right recipe across the 44-recipe catalogue (Hello, Read Data, Modify Data, SF APIs, Error Handling, Routing, Styling, Integration)
+- Front-loads the highest-stakes footgun (stale GraphQL codegen against an uncommitted schema → silent prod failure)
+- Defers cleanly to `sf-apex`, `sf-deploy`, and the `sf` / `npm` CLIs for live operations
+- Refuses production deploys and non-English orgs (beta restrictions)
+
+## When it triggers
+
+See the `description` field in `SKILL.md`. Short version: anywhere a Multi-Framework UI bundle, recipe, or Multi-Framework-specific package marker appears. **Not** generic React work.
+
+## Files
+
+- `SKILL.md` — main skill file (front-loads the WARNING, owns the routing table)
+- `references/recipes-routing.md` — full 44-recipe routing catalogue
+- `references/footguns.md` — extended failure-mode breakdown
+- `scripts/check_codegen_freshness.py` — pre-deploy validator that enforces fresh GraphQL codegen against the schema
+
+## Beta constraints (April 2026)
+
+- Open beta — scratch orgs and sandboxes only
+- English-default orgs only (`"language": "en_US"`)
+- Node.js v22+ required (v18 / v20 unsupported)
+- `sourceApiVersion: "66.0"` (Spring '26) or later
+
+## Source
+
+Content grounded in the official `trailheadapps/multiframework-recipes` repo and the Salesforce Headless 360 / Multi-Framework launch documentation.

--- a/skills/sf-react/SKILL.md
+++ b/skills/sf-react/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: sf-react
+description: "React on the Salesforce Multi-Framework runtime (Headless 360 / Agentforce 360 Platform). TRIGGER when: user creates or edits Multi-Framework UI bundles, touches a uiBundles/ directory, edits ui-bundle.json, .uibundle-meta.xml, .tsx files inside force-app/, or a package.json with @salesforce/sdk-data or @salesforce/vite-plugin-ui-bundle, or asks about 'React on Salesforce', 'Multi-Framework', 'Headless 360 React', 'Agentforce React app', or trailheadapps/multiframework-recipes patterns. DO NOT TRIGGER when: generic React work outside Salesforce (Next.js, plain Vite, Create-React-App with no platform context), Aura, Visualforce, or Lightning Web Components — for LWC use sf-lwc instead."
+license: MIT
+metadata:
+  version: "0.1.0"
+  author: "weytani"
+  scoring: "44 recipes across 8 categories — Multi-Framework open beta, sourceApiVersion 66.0"
+---
+
+# sf-react: React on Salesforce (Multi-Framework / Headless 360)
+
+## ⚠ WARNING: Stale GraphQL Codegen Silently Breaks Production
+
+Multi-Framework projects generate `schema.graphql` from the connected org and **deliberately do not commit it**. If `npm run graphql:schema` is skipped before `npm run build`, the build passes, lint passes, no warnings appear — but `graphql-operations-types.ts` is stale or missing, and field access against UIAPI's `{ value }` shape silently fails at runtime in production.
+
+**ALWAYS** run `npm run graphql:schema` before any `npm run build` in a Multi-Framework project. The bundled `scripts/check_codegen_freshness.py` validates this — run it before deploy. See `references/footguns.md` for the full failure-mode breakdown.
+
+---
+
+## When This Skill Owns the Task
+
+Scope: any work touching the Multi-Framework runtime — see "Variant Detection" below for the exact markers.
+
+Multi-Framework launched at **TDX 2026 (April 15, 2026)** as part of Headless 360 / the Agentforce 360 Platform, and it post-dates the model's training cutoff. It introduces three platform primitives that did not previously exist: **`@salesforce/sdk-data`** (UIAPI GraphQL data layer with `{ value }` field shape and Relay connections), **`@salesforce/vite-plugin-ui-bundle`** (Salesforce-aware Vite plugin emitting `uiBundles/` + `.uibundle-meta.xml`), and **GraphQL codegen against UIAPI** (`schema.graphql` introspected live from the org, never committed). It is currently in **open beta**: scratch orgs and sandboxes only (no production), `en_US` default language only, and **Node.js v22+** required (v18 and v20 are unsupported). It has replaced — not supplemented — the older React-on-Salesforce blueprints (Visualforce-embedded React, bearer-token REST against `/services/data`, `lightning-react-app`) for greenfield work.
+
+---
+
+## Variant Detection — Confirm It's Multi-Framework First
+
+Before writing any code, detect the variant. **If you see any of these markers**, you are in a Multi-Framework project:
+
+- `force-app/main/<package>/uiBundles/` directory (note: `uiBundles`, not `lwc`)
+- `ui-bundle.json` in the React app root (routing config: `outputDir`, `trailingSlash`, SPA fallback)
+- `.uibundle-meta.xml` metadata files
+- `package.json` deps include `@salesforce/sdk-data` or `@salesforce/vite-plugin-ui-bundle`
+- `sfdx-project.json` with `"sourceApiVersion": "66.0"` (Spring '26) or later
+- `codegen.yml` for GraphQL code generation
+- `vite.config.ts` referencing the Salesforce plugin (NOT Webpack, NOT Create-React-App)
+- Volta config pinning **Node.js v22+** (Multi-Framework requires v22; v18 and v20 are unsupported)
+
+If **none** of these markers are present, this is not a Multi-Framework project — stop and route the user elsewhere (see "Not Covered" below).
+
+---
+
+## Knowledge / Capability Boundary
+
+This skill **owns** as static reference:
+
+- The 44-recipe routing table — which recipe fits which task (`references/recipes-routing.md`)
+- UIAPI GraphQL shape: `{ value }` wrapping, Relay `edges → node` connections, `pageInfo` cursors
+- Salesforce scalar mappings for `codegen.yml` (Currency, Picklist, Date, DateTime, EncryptedString, IdOrRef)
+- Mutation input shapes (`RecordCreateInput`, `RecordUpdateInput`, `RecordDeleteInput`)
+- The three coexisting styling systems (SLDS / shadcn-ui / `design-system-react`) and when to pick which
+- `ui-bundle.json` schema and `.uibundle-meta.xml` shape
+- Beta restrictions (English-default orgs only, scratch + sandbox only, no production)
+- Authentication context (B2E only in beta; no client-side auth)
+
+This skill **does not own** — defer to live tools:
+
+- `sf project deploy start` — deployment (route to `sf-deploy`)
+- `sf org create scratch` / `sf org login web` — org setup (defer to CLI)
+- `npm run graphql:schema` — live org introspection (defer to CLI)
+- `npm run graphql:codegen` — code generation against schema (defer to CLI)
+- `npm run build` / `npm run lint` / `npm run test` / `npm run test:e2e` — build and test execution
+- Apex backend logic — route to `sf-apex`
+- LWC work — route to `sf-lwc`
+
+---
+
+## Footguns — Beta Platform, Sharp Edges
+
+### 1. Stale codegen against uncommitted schema (the WARNING above)
+**NEVER** assume types are fresh just because the build passed. **ALWAYS** run `scripts/check_codegen_freshness.py` before deploy.
+
+### 2. Non-English org → silent UI break
+Multi-Framework only works in orgs with `"language": "en_US"` as default. Other languages produce no runtime error — the UI simply fails to load. **ALWAYS** verify scratch org definitions include `"language": "en_US"`.
+
+### 3. No automatic cache invalidation after mutations
+LWC's `updateRecord()` notifies `@wire` adapters automatically; React has no equivalent. After a mutation you **MUST** manually patch local state — easy to forget when coming from LWC, and it leaves stale UI in the user's face. See the `Modify Data` recipes in `references/recipes-routing.md`.
+
+### 4. Extracting GraphQL queries to `src/api/` utilities (in recipes)
+The recipes repo's `AGENT.md` explicitly forbids this for recipe code — every recipe inlines its query/mutation so readers see the pattern. **NEVER** suggest DRY-extracting queries into shared utilities when authoring or modifying recipes. App code can extract; recipe code cannot.
+
+### 5. Mixing styling systems in one component
+SLDS, shadcn/ui, and `design-system-react` coexist in the same codebase. **NEVER** mix two systems in a single component. Pick one per component and document the choice. ESLint will not catch this.
+
+### 6. Production deploy attempts
+Multi-Framework is open beta. **NEVER** attempt `sf project deploy start --target-org <production>`. Redirect to scratch or sandbox.
+
+---
+
+## Routing — Which Recipe for Which Task
+
+The official `trailheadapps/multiframework-recipes` repo ships **44 recipes across 8 categories**. The full table lives in `references/recipes-routing.md`. Quick router:
+
+| If the user wants to... | Read recipe(s) | Category |
+|---|---|---|
+| Render a basic React component on the platform | `HelloWorld`, `BindingAccountName` | Hello (8) |
+| Read a single record from UIAPI | `SingleRecord` | Read Data |
+| List, filter, sort, paginate records | `ListOfRecords`, `FilteredList`, `SortedResults`, `PaginatedList` | Read Data |
+| Traverse parent → child relationships | `RelatedRecords` | Read Data |
+| Refetch data imperatively (button click) | `ImperativeRefetch` | Read Data |
+| Create / update / delete records | `CreateRecord`, `UpdateRecord`, `DeleteRecord` | Modify Data |
+| Handle GraphQL errors gracefully | `GraphqlErrors`, `LoadingErrorEmpty`, `ErrorBoundaryRecipe` | Error Handling |
+| Get current user / session context | `DisplayCurrentUser` | SF APIs |
+| Call REST UIAPI directly | `UiApiRest` | SF APIs |
+| Call custom Apex REST | `ApexRest` | SF APIs |
+| Add routing (links, params, navigation) | `LinkDemo`, `NavLinkDemo`, `RouteParameters`, `UseNavigate`, `NestedRoutes` | Routing (5) |
+| Style a component (pick one system) | `Button*`, `AccountCard*`, `Icons*` | Styling (9) |
+| Combine query + filter + UI in one screen | `SearchableAccountList`, `DashboardAliasedQueries` | Integration |
+
+**For training-gap content** — UIAPI `{ value }` shape, Relay connection pattern, scalar mappings, mutation input shapes, `ui-bundle.json` schema — read the relevant `references/` file before writing code. These primitives all post-date the model's training cutoff: they were renamed, replaced, or freshly GA'd as of 2026 (specifically the April 2026 Headless 360 launch). Patterns from earlier React-on-Salesforce integration approaches (e.g., bearer-token REST against `/services/data`, embedding React via Visualforce, or the older `lightning-react-app` blueprint) are deprecated and should not be used.
+
+---
+
+## Verification — How You Know It Worked
+
+Before declaring a Multi-Framework change done, **validate** all of:
+
+1. **Run `scripts/check_codegen_freshness.py <project-root>`** — exits 0 only if `schema.graphql` exists and `graphql-operations-types.ts` is newer than it. Exits non-zero with a remediation hint otherwise.
+2. **Run `npm run lint`** — Multi-Framework projects ship a strict ESLint config; passing lint validates recipe-style-guide compliance.
+3. **Run `npm run build`** in the React app directory. Treat any of the following TypeScript errors as **stale-codegen detected** (not as a code bug to fix in place) — re-run `npm run graphql:schema && npm run graphql:codegen`, then rebuild:
+   - `Property 'value' does not exist on type '...'` — UIAPI `{ value }` shape access against pre-codegen / mismatched types.
+   - `Cannot find module './generated/graphql-operations-types'` (or `'@/generated/graphql-operations-types'`, or any path ending in `graphql-operations-types`) — codegen output missing entirely.
+   - `Property '<FieldName>' does not exist on type 'Account' | 'Contact' | …` or `Type 'unknown' is not assignable to type '<ScalarName>Value'` — schema drift between the org and the generated types.
+4. **Run `npm run test:e2e`** in a scratch org with `"language": "en_US"` — actual UIAPI shape validation.
+5. **Confirm beta constraints** — scratch or sandbox target org, English-default language, Node.js v22+.
+
+If any of the above fail, **do not declare the task complete**. Surface the failure to the user with the exact command output.
+
+---
+
+## Not Covered — Out of Scope, Defer Elsewhere
+
+This skill explicitly **does not cover**:
+
+- **Plain React work outside Salesforce** (Next.js, Vite-only, Create-React-App, plain SPAs) — out of scope; the agent's general React knowledge applies.
+- **Lightning Web Components** — out of scope; route to `sf-lwc`.
+- **Apex controllers, triggers, business logic** — out of scope; route to `sf-apex`.
+- **Metadata deployment** — out of scope; route to `sf-deploy`.
+- **OmniStudio / FlexCard / DataMapper** — out of scope; route to `sf-omniscript`, `sf-flexcard`, `sf-datamapper`.
+- **Production-org deploys** — Multi-Framework is open beta; production is unsupported. Refuse and redirect.
+- **Non-English orgs** — beta restriction (`en_US` default only). Refuse and redirect.
+- **Aura components, Visualforce** — legacy frameworks; out of scope entirely.
+
+---
+
+## Handoff — What Comes Next
+
+After this skill completes its work, hand off explicitly:
+
+- For deployment → next step is `sf-deploy`
+- For Apex backend (controllers powering the React app) → next step is `sf-apex`
+- For test execution → user runs `npm test` or `npm run test:e2e` directly (skill defers, does not own test execution)
+- For converting an existing LWC into a Multi-Framework React equivalent → stay in `sf-react` (in scope)
+
+If the work crosses into deployment or backend logic, hand off cleanly — do not try to span the boundary.
+
+---
+
+## Output Format
+
+When finishing, report in this order:
+
+1. **Multi-Framework component(s) created or updated**
+2. **Recipe(s) referenced** — by name, from `references/recipes-routing.md`
+3. **Files changed** — paths
+4. **Codegen freshness** — `scripts/check_codegen_freshness.py` exit code and output
+5. **Beta-constraint verification** — language, org type, Node version
+6. **Next handoff step** — `sf-deploy`, `sf-apex`, or stay-in-skill
+
+Suggested shape:
+
+```text
+sf-react work: <summary>
+Recipes used: <names>
+Files: <paths>
+Codegen: fresh (check_codegen_freshness exit 0) | stale (FIX REQUIRED)
+Constraints: en_US ✓, scratch/sandbox ✓, Node v22 ✓
+Next: <handoff>
+```

--- a/skills/sf-react/references/footguns.md
+++ b/skills/sf-react/references/footguns.md
@@ -1,0 +1,85 @@
+# Footguns — Multi-Framework Beta Sharp Edges
+
+Six failure modes ordered by stakes. Read this before starting work in a Multi-Framework project.
+
+## 1. Stale GraphQL codegen → silent prod failure (highest stakes)
+
+**Setup.** Multi-Framework projects generate `schema.graphql` by introspecting the connected org. The schema is **deliberately not committed** to the repo — it's regenerated per developer, per scratch org. The Vite plugin runs codegen conditionally: only if `schema.graphql` exists.
+
+**Failure mode.** If `npm run graphql:schema` is skipped before `npm run build`:
+
+- Build passes silently (Vite skips codegen when schema is missing)
+- Lint passes
+- TypeScript may catch *some* shape mismatches but not all — UIAPI's `{ value }` wrapping and Relay `edges → node` shape leave room for `undefined` field access at runtime
+- Bundle ships, deploys, looks fine in dev
+- Specific records / specific fields fail at runtime in production with `Cannot read properties of undefined (reading 'value')` or similar
+
+**Why TypeScript doesn't save you.** The generated `graphql-operations-types.ts` is what binds your `.tsx` field accesses to actual UIAPI return shapes. Without fresh codegen, types fall back to looser shapes (or are missing entirely), and the compiler doesn't know to error.
+
+**Prevent it.**
+
+```bash
+npm run graphql:schema  # introspect org → write schema.graphql
+npm run graphql:codegen # generate graphql-operations-types.ts
+npm run build           # only safe to run after the above
+```
+
+The bundled `scripts/check_codegen_freshness.py <project-root>` enforces this — exits 0 only when both files exist and the generated types are newer than the schema.
+
+## 2. Non-English org → silent UI break
+
+Multi-Framework is locked to English-default orgs in beta. The check is on **default org language** (`Organization.LanguageLocaleKey`), not user locale. Other languages produce no runtime error — the UI simply fails to load (blank or partial render).
+
+**Prevent it.** In `config/project-scratch-def.json`:
+
+```json
+{
+  "language": "en_US"
+}
+```
+
+For sandboxes, confirm the default language is `en_US` before deploying.
+
+## 3. No automatic cache invalidation after mutations
+
+LWC's `updateRecord()` notifies all `@wire` adapters bound to the same record automatically. **React has no equivalent.** The Multi-Framework data SDK (`@salesforce/sdk-data`) leaves cache management to the developer.
+
+**Failure mode.** A user creates / updates / deletes a record. The mutation succeeds. The page still shows the old data because no `@wire` notification ever fires. The user clicks refresh, sees the new data, files a bug.
+
+**Prevent it.** After every mutation, manually update local state:
+
+```tsx
+const [accounts, setAccounts] = useState<Account[]>([]);
+const onCreate = async (input: RecordCreateInput) => {
+  const result = await sdk.executeGraphQL(CreateAccountMutation, { input });
+  setAccounts((prev) => [...prev, result.uiapi.AccountCreate.Record]);
+};
+```
+
+See `Modify Data → UpdateRecord` and `QueryMutationTogether` recipes for canonical patterns.
+
+## 4. Extracting GraphQL queries to `src/api/` utilities (in recipes)
+
+The `multiframework-recipes` repo's `AGENT.md` explicitly forbids extracting queries / mutations into shared utility files **inside recipe code**. Every recipe must inline its GraphQL so a reader can see the full pattern in one file.
+
+**Why it's a footgun.** An agent applying generic React DRY principles will instinctively suggest `src/api/accountQueries.ts`. This breaks the recipe's pedagogical contract and gets PRs rejected.
+
+**Application code is different.** Real apps may extract — the rule is recipe-specific.
+
+## 5. Mixing styling systems in one component
+
+Multi-Framework apps ship with **three styling systems coexisting**:
+
+- SLDS CSS classes (via `@salesforce-ux/design-system` 2.29.0+)
+- shadcn/ui + Tailwind + Lucide icons
+- `design-system-react` (drop-in React components matching SLDS)
+
+A single component using two systems renders inconsistently and confuses anyone reading the code. ESLint does not catch this.
+
+**Prevent it.** Pick one system per component. Document the choice in a comment when it isn't obvious from the imports.
+
+## 6. Production-org deploy attempts
+
+Multi-Framework is **open beta**. Deploys to production orgs are unsupported and may succeed at the metadata layer but fail at runtime, or be blocked outright.
+
+**Prevent it.** Always target a scratch org or sandbox. The skill should refuse to assist with `sf project deploy start --target-org <production>` and redirect to scratch / sandbox flow.

--- a/skills/sf-react/references/recipes-routing.md
+++ b/skills/sf-react/references/recipes-routing.md
@@ -1,0 +1,92 @@
+# Recipe Routing — trailheadapps/multiframework-recipes
+
+44 recipes across 8 categories. Source: https://github.com/trailheadapps/multiframework-recipes
+
+Use this as the lookup table when an agent needs to ground a Multi-Framework task in an official pattern.
+
+## Hello (8) — Platform-grounded React basics
+
+| Recipe | Use when |
+|---|---|
+| `HelloWorld` | Need the simplest possible Multi-Framework component as a starting point |
+| `BindingAccountName` | First introduction to fetching and binding data with the `{ value }` shape |
+| `ConditionalStatus` | Conditional render on a picklist value |
+| `ListOfAccounts` | List rendering with the Relay `edges → node` pattern |
+| `LifecycleFetch` | `useEffect` lifecycle plus async fetch |
+| `ParentToChild` | Props passing parent → child |
+| `ChildToParent` | Event handlers child → parent |
+| `StateManagement` | Local `useState` (no persistence) |
+
+## Read Data (8) — GraphQL queries against UIAPI
+
+| Recipe | Use when |
+|---|---|
+| `SingleRecord` | Basic single-record query, field access via `{ value }` |
+| `ListOfRecords` | Multiple records, basic pagination |
+| `FilteredList` | `where` clause filtering |
+| `SortedResults` | `orderBy` sorting |
+| `PaginatedList` | Relay cursors and `pageInfo` |
+| `RelatedRecords` | Parent-lookup `__r` traversal |
+| `ImperativeRefetch` | Refetch button, query re-run on demand |
+| `AliasedMultiObjectQuery` | Aliases for multi-object queries in one request |
+
+## Modify Data (5) — GraphQL mutations
+
+| Recipe | Use when |
+|---|---|
+| `CreateRecord` | New record creation, `RecordCreateInput` shape |
+| `UpdateRecord` | Patch + manual local state update (no auto cache invalidation in React) |
+| `DeleteRecord` | Delete with confirmation pattern |
+| `QueryMutationTogether` | Load record then mutate it |
+| `ServerErrorHandling` | `result.errors[]` vs throw |
+
+## Salesforce APIs (4) — Non-GraphQL platform APIs
+
+| Recipe | Use when |
+|---|---|
+| `DisplayCurrentUser` | Session context, current user info |
+| `UiApiRest` | REST UIAPI calls to `/services/data/v66.0/ui-api/records` |
+| `ApexRest` | Custom `@RestResource` callout |
+| `ConnectApi` | Social / Chatter Connect API |
+
+## Error Handling (3)
+
+| Recipe | Use when |
+|---|---|
+| `GraphqlErrors` | `result.errors[]` detection and surfacing |
+| `LoadingErrorEmpty` | Render-state machine: loading, error, empty |
+| `ErrorBoundaryRecipe` | React error boundary wrapping a feature |
+
+## Routing (5) — React Router 7 (note: `react-router`, not `react-router-dom`)
+
+| Recipe | Use when |
+|---|---|
+| `LinkDemo` | Basic `Link` component |
+| `NavLinkDemo` | `NavLink` active state |
+| `RouteParameters` | URL params via `useParams` |
+| `UseNavigate` | Programmatic navigation |
+| `NestedRoutes` | Nested route structure |
+
+## Styling (9) — Three systems side-by-side
+
+Three pairs of recipes, one per styling system, applied to the same UI element. The point is to demonstrate the choice — never mix two systems in a single component.
+
+| Recipe | System | Use when |
+|---|---|---|
+| `ButtonSLDS` / `AccountCardSLDS` / `IconsSLDS` | SLDS CSS classes on JSX | Maximum platform consistency |
+| `ButtonShadcn` / `AccountCardShadcn` / `IconsLucide` | shadcn/ui + Lucide | Modern component library, more flexibility |
+| `ButtonDSR` / `AccountCardDSR` / `IconsDSR` | `design-system-react` | Drop-in React components matching SLDS |
+
+## Integration (2) — Combined patterns
+
+| Recipe | Use when |
+|---|---|
+| `SearchableAccountList` | Query + filter + list + state in one screen |
+| `DashboardAliasedQueries` | Multi-object query with aliased results, dashboard layout |
+
+## Cross-cutting reminders
+
+- Every recipe inlines its GraphQL query/mutation (the recipes repo's `AGENT.md` forbids extracting them to `src/api/`).
+- Pick exactly one styling system per component.
+- After any mutation, manually patch local state (no `updateRecord()`-style auto-notify in React).
+- All UIAPI scalar fields are wrapped in `{ value }`. List fields use Relay `edges → node`.

--- a/skills/sf-react/scripts/check_codegen_freshness.py
+++ b/skills/sf-react/scripts/check_codegen_freshness.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# ABOUTME: Validates GraphQL codegen freshness in a Multi-Framework project.
+# ABOUTME: Exits 0 if generated types are newer than schema.graphql; non-zero with hint otherwise.
+
+"""
+Multi-Framework codegen freshness check.
+
+Usage:
+    python3 check_codegen_freshness.py <project-root>
+
+Exits 0 if schema.graphql exists and graphql-operations-types.ts is newer than it.
+Exits 1 with a remediation hint otherwise.
+Exits 2 on usage error.
+
+The skill front-loads this footgun in its WARNING block: schema.graphql is
+generated from the connected org and not committed; if `npm run graphql:schema`
+is skipped before `npm run build`, the build still passes but generated types
+are stale or missing, and field access against UIAPI's `{ value }` shape fails
+silently at runtime in production.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def find_first(root: Path, name: str) -> Path | None:
+    """Return the first matching file under root (BFS, depth-limited)."""
+    for path in root.rglob(name):
+        if "node_modules" in path.parts or ".git" in path.parts:
+            continue
+        return path
+    return None
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            "usage: check_codegen_freshness.py <project-root>",
+            file=sys.stderr,
+        )
+        return 2
+
+    root = Path(argv[1]).expanduser().resolve()
+    if not root.is_dir():
+        print(f"error: {root} is not a directory", file=sys.stderr)
+        return 2
+
+    print(f"sf-react codegen freshness check: {root}")
+
+    schema = find_first(root, "schema.graphql")
+    generated = find_first(root, "graphql-operations-types.ts")
+
+    if schema is None:
+        print("  ✗ schema.graphql not found")
+        print(
+            "    → Run `npm run graphql:schema` first to introspect the "
+            "connected org and write schema.graphql."
+        )
+        print(
+            "    → Schema files are deliberately not committed; you must "
+            "regenerate from a fresh scratch/sandbox login."
+        )
+        return 1
+
+    print(f"  ✓ schema.graphql found at {schema.relative_to(root)}")
+
+    if generated is None:
+        print("  ✗ graphql-operations-types.ts not found")
+        print(
+            "    → Run `npm run graphql:codegen` to generate operation "
+            "types against the schema."
+        )
+        return 1
+
+    print(
+        f"  ✓ graphql-operations-types.ts found at "
+        f"{generated.relative_to(root)}"
+    )
+
+    schema_mtime = schema.stat().st_mtime
+    generated_mtime = generated.stat().st_mtime
+
+    if generated_mtime < schema_mtime:
+        print("  ✗ generated types are STALE — schema is newer than codegen output")
+        print(
+            "    → Run `npm run graphql:codegen` to regenerate "
+            "graphql-operations-types.ts against the current schema."
+        )
+        print(
+            "    → Build will pass but UIAPI field access (`{ value }` shape) "
+            "may fail silently in production."
+        )
+        return 1
+
+    print("  ✓ generated types are fresh (newer than schema)")
+    print("codegen freshness OK — safe to proceed to build / deploy")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Description

Adds a new `sf-react` skill that grounds an LLM agent in the official `trailheadapps/multiframework-recipes` patterns for Salesforce **Multi-Framework** — the new native-React runtime announced at TDX 2026 (April 15 2026) as part of Headless 360. Multi-Framework is currently in open beta (scratch orgs and sandboxes only, English-default only, Node.js v22+).

The skill follows the existing `sf-lwc` shape (frontmatter with TRIGGER / DO NOT TRIGGER, structured SKILL.md, `references/` and `scripts/` folders, README and CREDITS).

Closes #63.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other

## What's in the bundle

- `SKILL.md` — front-loads the highest-stakes footgun (stale GraphQL codegen against an uncommitted `schema.graphql` → silent prod failure), variant-detection markers, the 44-recipe routing table, knowledge/capability boundary (defers to `sf-apex`, `sf-deploy`, `sf-lwc`), explicit non-coverage list, verification steps with concrete TypeScript error signatures, and handoff protocol
- `references/recipes-routing.md` — full 44-recipe catalogue across 8 categories (Hello, Read Data, Modify Data, SF APIs, Error Handling, Routing, Styling, Integration)
- `references/footguns.md` — six failure-mode breakdowns with prevention steps
- `scripts/check_codegen_freshness.py` — zero-dep Python validator that exits 0 only when generated GraphQL types are newer than `schema.graphql`; prints concrete remediation hints otherwise. Pre-deploy gate.
- `README.md`, `CREDITS.md`

## Triggering

The skill is scoped tightly to **React-on-Salesforce-Multi-Framework**, not generic React. It triggers on platform markers:

- `uiBundles/` directory inside `force-app/`
- `ui-bundle.json`, `.uibundle-meta.xml`
- `package.json` deps `@salesforce/sdk-data` or `@salesforce/vite-plugin-ui-bundle`
- User phrases like "React on Salesforce", "Multi-Framework", "Headless 360 React", "Agentforce React app"

It explicitly does NOT trigger on plain React / Next.js / Vite / Create-React-App with no Salesforce context, nor on Aura / Visualforce / LWC (defers to `sf-lwc`).

## Testing

- `python3 tools/check_repo_hygiene.py` → passes (430 markdown files + asset naming)
- `python3 tools/install.py --dry-run` → passes
- Skill validated against an external structural validator (Kinney 9-gap framework + 3 extensions) — passes 12/12
- `scripts/check_codegen_freshness.py` smoke-tested (exit 2 on missing dir, exit 1 with remediation on missing schema)
- Content cross-checked against the live `trailheadapps/multiframework-recipes` repo (README, CONTRIBUTING, AGENT.md, `.airules/RECIPE-STYLE-GUIDE.md`, recipe directory tree)

## Checklist

- [x] Validated with `tools/check_repo_hygiene.py`
- [x] Updated relevant documentation (README + SKILL.md + CREDITS)
- [x] Tested manually
- [x] No breaking changes — additive only
- [x] Frontmatter follows the simplified Anthropic plugin format (`name`, `description`, `license`, `metadata`)

## AI-Assisted Authoring (per CONTRIBUTING.md AI policy)

Disclosing transparently: the skill was authored via a structured interview protocol that closes Steve Kinney's nine universal skill gaps (plus three extensions for description hygiene, verification, and handoff), then refined via two iterations of judge-feedback against the same gap criteria. Final composite score 9.75/10. Content was personally reviewed and validated against the source `multiframework-recipes` repo and the structural validator before submission.

## Related Issues

Closes #63