### PR TITLE
feat(sf-multiframework): add Salesforce Multi-Framework React (UIBundle) skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 [![Author](https://img.shields.io/badge/Author-Jag_Valaiyapathy-blue?logo=github)](https://github.com/Jaganpro)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Skills](https://img.shields.io/badge/Skills-36-4F46E5)](#available-skills)
+[![Skills](https://img.shields.io/badge/Skills-37-4F46E5)](#available-skills)
 [![Claude Code Agents](https://img.shields.io/badge/Claude_Code_Agents-7-059669)](#agent-team)
 [![Standard](https://img.shields.io/badge/Agent_Skills-Compatible-0F766E)](https://agentskills.io)
 
 A reusable skill library for **Salesforce-focused coding agents**—covering Apex, Flow, LWC, SOQL, metadata, Data Cloud, integration, testing, deployment, Agentforce workflows, and Flex Credit estimation.
 
-**Included:** 36 Salesforce skills, 7 specialist Claude Code agents, a shared hook system for guardrails and auto-validation, and LSP-backed feedback for Apex, LWC, and Agent Script.
+**Included:** 37 Salesforce skills, 7 specialist Claude Code agents, a shared hook system for guardrails and auto-validation, and LSP-backed feedback for Apex, LWC, and Agent Script.
 
 > Recommended workflow for this repository: agent-first development in Claude Code, Pi, and similar coding agents. VS Code is optional tooling, not the primary operating model.
 >
@@ -28,7 +28,7 @@ The library is organized by capability area so you can scan quickly, pick the ri
 
 | Area | Skills | Best for |
 |---|---|---|
-| 💻 **Development** | [sf-apex](skills/sf-apex/), [sf-flow](skills/sf-flow/), [sf-lwc](skills/sf-lwc/), [sf-soql](skills/sf-soql/) | Apex, Flow, LWC, and query development |
+| 💻 **Development** | [sf-apex](skills/sf-apex/), [sf-flow](skills/sf-flow/), [sf-lwc](skills/sf-lwc/), [sf-soql](skills/sf-soql/), [sf-multiframework](skills/sf-multiframework/) | Apex, Flow, LWC, React (UIBundle), and query development |
 | 🧪 **Quality** | [sf-testing](skills/sf-testing/), [sf-debug](skills/sf-debug/) | Test execution, coverage analysis, and debug-log troubleshooting |
 | 📦 **Foundation** | [sf-metadata](skills/sf-metadata/), [sf-data](skills/sf-data/), [sf-docs](skills/sf-docs/), [sf-permissions](skills/sf-permissions/) | Metadata generation, data operations, access analysis, and official Salesforce docs retrieval |
 | 🔌 **Integration** | [sf-connected-apps](skills/sf-connected-apps/), [sf-integration](skills/sf-integration/) | OAuth, External Client Apps, Named Credentials, callouts, and events |
@@ -78,7 +78,7 @@ npx skills add Jaganpro/sf-skills --list
 curl -sSL https://raw.githubusercontent.com/Jaganpro/sf-skills/main/tools/install.sh | bash
 ```
 
-This installs 36 skills, 7 specialist agents, a shared hook system, and the local LSP engine. It also configures LLM-powered guardrails (Haiku prompt hook), SOQL schema validation, Prettier auto-formatting, Code Analyzer (PMD/ESLint), and debug log analysis (Haiku agent hook).
+This installs 37 skills, 7 specialist agents, a shared hook system, and the local LSP engine. It also configures LLM-powered guardrails (Haiku prompt hook), SOQL schema validation, Prettier auto-formatting, Code Analyzer (PMD/ESLint), and debug log analysis (Haiku agent hook).
 
 > **Data Cloud note:** the installer brings in the `sf-datacloud-*` skills, but the external community `sf data360` CLI runtime is still a separate prerequisite. On first-time install the installer can prompt for it, or you can request it explicitly with `--with-datacloud-runtime`.
 
@@ -145,7 +145,7 @@ python3 ~/.claude/sf-skills-install.py --profile delete old
 
 ```
 ~/.claude/
-├── skills/                    # 36 Salesforce skills
+├── skills/                    # 37 Salesforce skills
 │   ├── sf-apex/SKILL.md
 │   ├── sf-flow/SKILL.md
 │   └── ... (33 more)
@@ -462,6 +462,16 @@ This is the working mental model for the ecosystem: foundation and integration s
 "Set up Lightning Message Service for cross-component communication"
 ```
 
+### ⚛️ React / Multi-Framework (UIBundle)
+```
+"Scaffold a new UIBundle React app with Vite and TypeScript"
+"Wire up the Data SDK to query Accounts with GraphQL"
+"Integrate the Agentforce Conversation Client (ACC) in my React component"
+"Deploy my UIBundle to a sandbox org"
+"Should I use React or LWC for this Salesforce UI?"
+"Generate codegen.yml for @salesforce/sdk-data GraphQL types"
+```
+
 ### 🔍 SOQL Queries
 ```
 "Query all Accounts with more than 5 Contacts"
@@ -603,6 +613,7 @@ sf-industry-commoncore-{name}  # Industries Common Core (omnistudio)
 | 🔗 | `sf-integration` | Named Credentials, External Services, REST/SOAP, Platform Events, CDC | ✅ Live |
 | 📊 | `sf-diagram-mermaid` | Mermaid diagrams for OAuth, ERD, integrations, architecture | ✅ Live |
 | ⚡ | `sf-lwc` | Lightning Web Components, Jest, LMS | ✅ Live |
+| ⚛️ | `sf-multiframework` | React UIBundle apps on Agentforce 360 Platform — Data SDK, GraphQL, ACC, Vite, deploy | ✅ Live (Beta) |
 | 🔍 | `sf-soql` | Natural language to SOQL, optimization | ✅ Live |
 | 🧪 | `sf-testing` | Test execution, coverage, bulk testing | ✅ Live |
 | 🐛 | `sf-debug` | Debug log analysis, governor fixes | ✅ Live |
@@ -665,7 +676,7 @@ sf-industry-commoncore-{name}  # Industries Common Core (omnistudio)
 | 🏦 | `sf-industry-finserv` | KYC, AML, Wealth Management | 📋 Planned |
 | 💵 | `sf-industry-revenue` | CPQ, Billing, Revenue Lifecycle | 📋 Planned |
 
-**Current repo state:** 36 live skills today, with additional cloud, security, AI, and industry roadmap items still planned.
+**Current repo state:** 37 live skills today, with additional cloud, security, AI, and industry roadmap items still planned.
 
 </details>
 

--- a/skills/sf-multiframework/CREDITS.md
+++ b/skills/sf-multiframework/CREDITS.md
@@ -1,0 +1,42 @@
+# Credits
+
+## sf-multiframework Skill
+
+Part of the **SF Skills** family authored by [Jag Valaiyapathy](https://github.com/Jaganpro). This skill follows the same format, rubric, and cross-skill orchestration conventions used across the `sf-*` skills — treat the Jag repo as the framework.
+
+## Authors & Contributors
+
+- **Jag Valaiyapathy** — skill framework, format, rubric, cross-skill conventions
+- **Dylan Andersen** — `sf-multiframework` skill body, reference expansion, recipe-pattern distillation
+
+## References & Inspiration
+
+### Official Salesforce Documentation
+
+- [Build a React App with Salesforce Multi-Framework (Beta) — Overview](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-overview.html)
+- [Configure Your Org for React Development (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-setup.html)
+- [Integrate Your React App with the Agentforce 360 Platform (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-integrate.html)
+- [Develop a React App Manually (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-develop.html)
+- [Data SDK and GraphQL (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-data-sdk.html)
+- [Access Record Data with Data SDK (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-data-sdk-usage.html)
+- [Error Handling in Data SDK (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-data-sdk-graphql-error.html)
+- [Style Your React Apps (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-styling.html)
+- [Integrate Agentforce Conversation Client (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-acc.html)
+- [React vs LWC (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-lwc-diff.html)
+
+### Reference Implementation
+
+- [`trailheadapps/multiframework-recipes`](https://github.com/trailheadapps/multiframework-recipes) — canonical React-on-Salesforce recipes; `AGENT.md` in that repo was a primary input for recipe conventions, data-access patterns, and styling guidance.
+
+### Related SF Skills (Jag's framework)
+
+- [`sf-ai-agentforce`](../sf-ai-agentforce/SKILL.md) — Builder metadata agents (ACC target)
+- [`sf-ai-agentscript`](../sf-ai-agentscript/SKILL.md) — `.agent` authoring bundles
+- [`sf-lwc`](../sf-lwc/SKILL.md) — LWC authoring
+- [`sf-apex`](../sf-apex/SKILL.md) — Apex classes / `@RestResource`
+- [`sf-deploy`](../sf-deploy/SKILL.md) — metadata deploy orchestration
+- [`sf-permissions`](../sf-permissions/SKILL.md) — permission sets for UI bundles
+
+## License
+
+MIT License — see [LICENSE](LICENSE).

--- a/skills/sf-multiframework/LICENSE
+++ b/skills/sf-multiframework/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Jag Valaiyapathy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/sf-multiframework/README.md
+++ b/skills/sf-multiframework/README.md
@@ -1,0 +1,120 @@
+# sf-multiframework
+
+⚛️ **Salesforce Multi-Framework (Beta) skill** — Build React apps that run on the Agentforce 360 Platform via the `UIBundle` metadata type.
+
+> Part of **Jag Valaiyapathy's SF Skills** framework — same format, rubric, and cross-skill orchestration conventions as [`sf-ai-agentforce`](../sf-ai-agentforce/), [`sf-ai-agentscript`](../sf-ai-agentscript/), [`sf-lwc`](../sf-lwc/), [`sf-apex`](../sf-apex/). Built from official [Salesforce Developer documentation](references/official-sources.md) and [`trailheadapps/multiframework-recipes`](https://github.com/trailheadapps/multiframework-recipes). Works in any MCP-capable agent or IDE — Agentforce Vibes is optional, not required.
+
+> Beta status: sandbox + scratch orgs only, default language must be `en_US`. Once enabled in an org, the feature **cannot be disabled**.
+
+## Features
+
+- ✅ End-to-end React app authoring on the Salesforce Platform
+- ✅ `UIBundle` metadata, `ui-bundle.json`, and `.uibundle-meta.xml` reference
+- ✅ Data SDK (`@salesforce/sdk-data`) + GraphQL UI API patterns
+- ✅ Codegen workflow for type-safe GraphQL operations
+- ✅ Strict / Tolerant / Permissive error-handling strategies
+- ✅ Agentforce Conversation Client (ACC) embed patterns
+- ✅ Three styling tracks: SLDS blueprints · `design-system-react` · Tailwind + shadcn
+- ✅ Internal (App Launcher) vs External (Experience Cloud) app templates
+- ✅ Cross-skill orchestration with `sf-apex`, `sf-ai-agentforce`, `sf-deploy`
+
+## Requirements
+
+| Requirement | Value |
+|---|---|
+| Org type | Sandbox or Scratch (Beta) |
+| Default language | `en_US` |
+| API version | v66.0+ |
+| Node.js | v22+ |
+| `sf` CLI | latest with `@salesforce/plugin-ui-bundle-dev` |
+| License (external apps) | Customer / Partner Community user licenses |
+| ACC license | Agentforce + Employee Agent configured |
+
+## Quick Start
+
+### 1. Enable Multi-Framework in your org
+Setup → "Salesforce Multi-Framework" → **Enable Beta**.
+
+### 2. Install the CLI plugin
+```bash
+sf plugins install @salesforce/plugin-ui-bundle-dev
+```
+
+### 3. Scaffold an app
+```bash
+# Internal employee app (App Launcher target)
+sf template generate ui-bundle --name myApp --template reactinternalapp
+
+# External B2B/B2C portal (Experience Cloud target)
+sf template generate ui-bundle --name myApp --template reactexternalapp
+```
+
+### 4. Develop locally
+```bash
+cd force-app/main/default/uiBundles/myApp
+npm install
+npm run graphql:schema      # introspect connected org
+npm run graphql:codegen     # generate types
+npm run dev                 # Vite dev server
+```
+
+### 5. Deploy
+```bash
+npm run build
+cd ../../../../..
+sf project deploy start --source-dir force-app/main/default/uiBundles/myApp --target-org TARGET
+```
+
+## Scoring System
+
+| Category | Points | Focus |
+|---|---|---|
+| Project Structure | 20 | `uiBundles/` layout, metadata files, output dir |
+| Routing & Hosting | 15 | `ui-bundle.json` SPA fallback, target match |
+| Data Access | 25 | Data SDK usage, GraphQL `{ value }` shape, error strategy |
+| Styling Discipline | 10 | One system per component, SLDS focus tokens |
+| ACC Integration | 15 | Cookies, Trusted Domains, mount lifecycle |
+| Deployment Readiness | 15 | Build artifacts, file-count budget, target org sanity |
+
+**Thresholds:** 90+ Excellent · 75–89 Good · 60–74 Needs Work · <60 Block deploy
+
+Full rubric: [references/scoring-rubric.md](references/scoring-rubric.md)
+
+## Key Rules
+
+1. **Use `@salesforce/sdk-data`** — never raw `fetch()` / `axios` to Salesforce endpoints.
+2. **GraphQL UI API wraps every field in `{ value }`** — comment this for React-first developers.
+3. **`ui-bundle.json` needs `routing.fallback: "index.html"`** for SPA refresh on sub-routes.
+4. **`.uibundle-meta.xml` `target` is binding** — `AppLauncher` vs `Experience` cannot be hot-swapped.
+5. **ACC requires My Domain cookies + Trusted Domains for Inline Frames + Agentforce preference** — all three.
+6. **One styling system per component** — mixing SLDS + Tailwind inside a single component is the most common review failure.
+7. **Beta = sandbox + scratch only, `en_US` only**. DE orgs and Playgrounds are unsupported.
+8. **Multi-Framework can't be disabled** once enabled in an org. Treat the toggle as one-way.
+9. **UIBundle has a 2,500-file ceiling** — prune `dist/` source maps and unused assets.
+10. **Inside a React UI bundle**, `lightning/*` modules, `@wire`, and most `@salesforce/*` packages are **not** supported (`@salesforce/sdk-data`, the ACC, and `@salesforce/ui-bundle` are exceptions).
+
+## Documentation
+
+| Document | Description |
+|---|---|
+| [SKILL.md](SKILL.md) | Main entry point with rules and workflow |
+| [references/](references/) | Topic-specific deep guides |
+| [assets/](assets/) | Reference `ui-bundle.json`, metadata, and code snippets |
+
+## Cross-Skill Workflow
+
+```
+sf-apex (REST endpoints) ─┐
+sf-ai-agentforce (Agent) ─┤→  sf-multiframework  →  sf-deploy
+sf-permissions (PSets) ───┘                          (CI deploy)
+```
+
+## Official Resources
+
+- [React App Overview (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-overview.html)
+- [Org Configuration (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-setup.html)
+- [Multi-Framework Recipes (GitHub)](https://github.com/trailheadapps/multiframework-recipes)
+
+## License
+
+MIT

--- a/skills/sf-multiframework/SKILL.md
+++ b/skills/sf-multiframework/SKILL.md
@@ -87,7 +87,7 @@ Verify these before authoring or fixing any Multi-Framework app:
 4. **App lives under `uiBundles/<appName>/`** with both `ui-bundle.json` and `<appName>.uibundle-meta.xml`.
 5. **`ui-bundle.json` `outputDir` matches the build output** (`dist/` for Vite).
 6. **SPA fallback** is set: `routing.fallback: "index.html"` for client-side routing.
-7. **`apiVersion` matches the target org** (e.g. `v66.0`).
+7. **API version is managed by `sfdx-project.json` and deploy API version**. Current UI bundle validators can reject `apiVersion` inside `ui-bundle.json`.
 8. **`outputDir` build artifacts exist before deploy** — run `npm run build` inside the bundle directory.
 9. **For external apps**: `digitalExperiences/.../sfdc_cms_site/content.json` has `appContainer: true` and `appSpace: "<namespace>__<DeveloperName>"` (or `c__<DeveloperName>` if no namespace).
 10. **For ACC**: My Domain "Require first-party use of Salesforce cookies" is **unchecked**, and the host domain is registered under **Trusted Domains for Inline Frames** (Lightning Out type).
@@ -140,7 +140,6 @@ For SPAs, you almost always need:
 ```json
 {
   "outputDir": "dist",
-  "apiVersion": "v66.0",
   "routing": {
     "fileBasedRouting": true,
     "trailingSlash": "never",
@@ -224,7 +223,7 @@ Dev server URL must be added to **Trusted Domains for Inline Frames** if you use
 ### Phase 4 — Build and deploy
 
 ```bash
-npm run build                         # tsc -b && vite build → dist/
+npm run build                         # tsc --noEmit && vite build → dist/
 cd ../../../../..                     # back to project root
 sf project deploy start \
   --source-dir force-app/main/default/uiBundles/myApp \
@@ -344,6 +343,9 @@ You can mix at the **app shell** vs **recipe/page** boundary, but **don't mix in
 | External app deploys but never appears in Digital Experiences | `appContainer: true` or `appSpace` not set, or namespace prefix wrong | [references/templates.md](references/templates.md) |
 | Mutation succeeds but read-back errors | UI API mutation return shape can't include some fields — switch to Permissive error strategy | [references/error-handling.md](references/error-handling.md) |
 | Build succeeds but deploy fails with file count error | UIBundle 2,500-file limit; prune `dist/` source maps or unused assets | [references/troubleshooting.md](references/troubleshooting.md) |
+| Deploy fails on `apiVersion`, `isEnabled`, or unknown `ui-bundle.json` keys | UIBundle metadata/runtime schema drift; use `isActive` + `version`, omit `apiVersion` from `ui-bundle.json` | [references/project-structure.md](references/project-structure.md), [references/ci-deploy.md](references/ci-deploy.md) |
+| Deploy includes `vite.config.js`, `.d.ts`, or `*.tsbuildinfo` | `tsc -b` emitted TypeScript artifacts into the bundle root | [references/project-structure.md](references/project-structure.md), [references/ci-deploy.md](references/ci-deploy.md) |
+| `npm install` fails with Vite peer conflict | Salesforce Vite plugin lags the latest Vite major | [references/project-structure.md](references/project-structure.md), [references/troubleshooting.md](references/troubleshooting.md) |
 | `sf template generate ui-bundle` is not recognized | `@salesforce/plugin-ui-bundle-dev` not installed | [references/cli-guide.md](references/cli-guide.md) |
 | Beta toggle missing in Setup | org is DE / Playground (not supported), or default language ≠ `en_US` | [references/setup.md](references/setup.md) |
 | Navigation works locally, breaks in Lightning Experience | `basename` not derived from `SFDC_ENV.basePath` | [references/react-router.md](references/react-router.md) |

--- a/skills/sf-multiframework/SKILL.md
+++ b/skills/sf-multiframework/SKILL.md
@@ -1,0 +1,428 @@
+---
+name: sf-multiframework
+description: >
+  Salesforce Multi-Framework (Beta) skill for building React apps that run on
+  the Agentforce 360 Platform.
+  TRIGGER when user creates or edits UI bundles (`uiBundles/`), authors React
+  apps deployed via `UIBundle` metadata, configures `ui-bundle.json` /
+  `.uibundle-meta.xml`, uses `@salesforce/sdk-data` (Data SDK + GraphQL), wires
+  up the Agentforce Conversation Client (ACC) in React, scaffolds with
+  `sf template generate ui-bundle`, or asks about React vs LWC choice on
+  Salesforce.
+  DO NOT TRIGGER when the work is pure LWC (use sf-lwc), generic Apex
+  (use sf-apex), Builder-managed Agentforce metadata only
+  (use sf-ai-agentforce), or `.agent` script files (use sf-ai-agentscript).
+license: MIT
+compatibility: "Beta. Requires API v66.0+, Node.js 22+, sandbox or scratch org with default language en_US, and @salesforce/plugin-ui-bundle-dev."
+metadata:
+  version: "1.0.0"
+  author: "Jag Valaiyapathy"
+  maintainer: "Dylan Andersen"
+  scoring: "100 points across 6 categories"
+  sources: "Salesforce Developer Documentation + trailheadapps/multiframework-recipes"
+  framework: "Jag Valaiyapathy SF Skills (same format / rubric / orchestration as sf-ai-agentforce, sf-ai-agentscript, sf-lwc, sf-apex)"
+---
+
+# sf-multiframework
+
+Salesforce **Multi-Framework (Beta)** lets you build modern frontend apps — currently **React** — that run on the Agentforce 360 Platform via the `UIBundle` metadata type. This skill is the code-first authoring path: scaffolding a project, wiring Data SDK + GraphQL, integrating the Agentforce Conversation Client, styling, and deploying.
+
+> **Sources & framework.** Built from the official [Salesforce developer documentation](references/official-sources.md) (the `reactdev-*` pages under `developer.salesforce.com/docs/platform/einstein-for-devs` and `code-builder`) and code patterns distilled from [`trailheadapps/multiframework-recipes`](https://github.com/trailheadapps/multiframework-recipes). Follows the format and conventions of **Jag Valaiyapathy's SF Skills framework** — same rubric structure, same cross-skill orchestration pattern, same activation-checklist-first approach as `sf-ai-agentforce`, `sf-ai-agentscript`, `sf-lwc`, and `sf-apex`.
+
+> **Usable in any MCP-capable agent or IDE.** Agentforce Vibes is *one* authoring surface; this skill is designed for developers who work directly against the `sf` CLI and the Data SDK without requiring a specific assistant.
+
+> Status: **Beta**. Sandbox + scratch orgs only. English (`en_US`) default language required. Not yet available in Developer Edition orgs or Trailhead Playgrounds.
+
+> Start here: [references/activation-checklist.md](references/activation-checklist.md)
+> New to the feature? Read [references/overview.md](references/overview.md) then [references/setup.md](references/setup.md).
+
+---
+
+## When This Skill Owns the Task
+
+Use `sf-multiframework` when the work involves:
+
+- creating or editing files inside `force-app/main/.../uiBundles/<appName>/`
+- authoring `ui-bundle.json` and `.uibundle-meta.xml`
+- scaffolding via `sf template generate ui-bundle` (`reactinternalapp` / `reactexternalapp`)
+- using `@salesforce/sdk-data` (`createDataSDK`, `gql`, `dataSdk.graphql?.()`, `dataSdk.fetch?.()`)
+- generating GraphQL types via codegen (`schema.graphql`, `graphql-operations-types.ts`)
+- embedding the Agentforce Conversation Client (`@salesforce/agentforce-conversation-client`)
+- choosing styling (SLDS blueprints vs `@salesforce/design-system-react` vs Tailwind/shadcn)
+- deploying React UI bundles via `sf project deploy start --source-dir <bundle>`
+- comparing React (Multi-Framework) vs LWC for a given use case
+
+Delegate elsewhere when:
+
+- task is pure LWC authoring → [sf-lwc](../sf-lwc/SKILL.md)
+- writing/maintaining Apex called from the React app → [sf-apex](../sf-apex/SKILL.md)
+- the Conversation Client target is a Builder-managed Employee Agent and the work is on the agent itself → [sf-ai-agentforce](../sf-ai-agentforce/SKILL.md) or [sf-ai-agentscript](../sf-ai-agentscript/SKILL.md)
+- agent testing → [sf-ai-agentforce-testing](../sf-ai-agentforce-testing/SKILL.md)
+- generic deployment troubleshooting unrelated to UI bundle specifics → [sf-deploy](../sf-deploy/SKILL.md)
+
+---
+
+## Required Context to Gather First
+
+Before authoring or fixing anything, infer or ask:
+
+1. **Org type**: Sandbox or Scratch? (DE / Playgrounds are not supported in Beta.)
+2. **App target**: `AppLauncher` (internal employee app) or `Experience` (external B2B/B2C portal)?
+3. **Template**: `reactinternalapp`, `reactexternalapp`, or no template (manual setup)?
+4. **ACC needed?** If yes, is the agent an Employee Agent? Are cookies + Trusted Domains configured?
+5. **Data access pattern**: GraphQL (preferred), UI API REST, or Apex REST?
+6. **Styling system**: SLDS blueprints, `design-system-react`, or Tailwind/shadcn?
+7. **Default language is `en_US`?** If not, scratch org def must set it.
+
+---
+
+## Activation Checklist
+
+Verify these before authoring or fixing any Multi-Framework app:
+
+1. **Org has Salesforce Multi-Framework (Beta) enabled** in Setup. (Once enabled, **cannot be disabled**.)
+2. **Salesforce CLI is current** and `@salesforce/plugin-ui-bundle-dev` is installed:
+   `sf plugins install @salesforce/plugin-ui-bundle-dev`
+3. **Node.js v22+** and **npm** installed.
+4. **App lives under `uiBundles/<appName>/`** with both `ui-bundle.json` and `<appName>.uibundle-meta.xml`.
+5. **`ui-bundle.json` `outputDir` matches the build output** (`dist/` for Vite).
+6. **SPA fallback** is set: `routing.fallback: "index.html"` for client-side routing.
+7. **`apiVersion` matches the target org** (e.g. `v66.0`).
+8. **`outputDir` build artifacts exist before deploy** — run `npm run build` inside the bundle directory.
+9. **For external apps**: `digitalExperiences/.../sfdc_cms_site/content.json` has `appContainer: true` and `appSpace: "<namespace>__<DeveloperName>"` (or `c__<DeveloperName>` if no namespace).
+10. **For ACC**: My Domain "Require first-party use of Salesforce cookies" is **unchecked**, and the host domain is registered under **Trusted Domains for Inline Frames** (Lightning Out type).
+11. **GraphQL schema is generated from a connected org** (`npm run graphql:schema`) before running codegen.
+12. **Use `@salesforce/sdk-data`** for all Salesforce API calls — never `fetch()` or `axios` directly to Salesforce endpoints.
+13. **Optional chaining** on SDK methods: `sdk.graphql?.()`, `sdk.fetch?.()` — they may not exist in every surface.
+14. **Only one UI bundle deploys per metadata push** — keep changes scoped to one app per deploy when possible.
+15. **UIBundle has a 2,500-file ceiling** — keep `dist/` lean.
+
+Expanded version: [references/activation-checklist.md](references/activation-checklist.md)
+
+---
+
+## Non-Negotiable Rules
+
+### 1) Use the Data SDK — never raw `fetch()` to Salesforce
+
+`@salesforce/sdk-data` handles auth, CSRF, and base-path resolution across surfaces (Lightning Experience, Experience Cloud, local Vite dev). Bypassing it breaks one or more of those surfaces.
+
+```ts
+import { createDataSDK, gql } from "@salesforce/sdk-data";
+const sdk = await createDataSDK();
+const res = await sdk.graphql?.(MY_QUERY, variables);
+```
+
+### 2) Prefer GraphQL UI API — fall back deliberately
+
+Order of preference for data access:
+
+1. `sdk.graphql?.()` for queries and mutations
+2. `sdk.fetch?.()` for whitelisted UI API REST / Apex REST endpoints
+3. Apex REST when GraphQL can't express the operation
+
+Never call `axios` or raw `fetch()` against Salesforce. See [references/data-sdk.md](references/data-sdk.md) for the supported endpoint list.
+
+### 3) UI API GraphQL responses wrap every field in `{ value }`
+
+```ts
+account.Name.value;          // "Acme Corp"
+account.Industry.value;      // "Technology"
+response.uiapi.query.Account.edges?.map(e => e?.node);
+```
+
+This is a Salesforce-specific shape, not standard GraphQL. Comment it in code aimed at React-first developers.
+
+### 4) `ui-bundle.json` is the routing contract
+
+For SPAs, you almost always need:
+
+```json
+{
+  "outputDir": "dist",
+  "apiVersion": "v66.0",
+  "routing": {
+    "fileBasedRouting": true,
+    "trailingSlash": "never",
+    "fallback": "index.html"
+  }
+}
+```
+
+Without `fallback: "index.html"` a hard refresh on `/dashboard` returns 404.
+
+### 5) `.uibundle-meta.xml` `target` is binding
+
+- `AppLauncher` → app appears in App Launcher (default).
+- `Experience` → app is hosted by an Experience Cloud site and is **only** discoverable through that site's metadata. External apps require `digitalExperienceConfigs/`, `digitalExperiences/`, `networks/`, and `sites/` to coexist.
+
+### 6) ACC requires explicit org configuration
+
+For Agentforce Conversation Client to render in a React app:
+
+- An **Employee Agent** with topics + actions must exist and Agentforce must be enabled.
+- **My Domain** → uncheck *Require first-party use of Salesforce cookies*.
+- **Session Settings** → add the host origin (e.g. `http://localhost:5173`) under **Trusted Domains for Inline Frames** with iFrame type **Lightning Out**.
+- ACC is built on **Lightning Out 2.0** as an LWCI; embed via `@salesforce/agentforce-conversation-client`'s `createAccWidget`.
+
+Skipping any of these is the #1 cause of "the chat panel won't load" errors. See [references/acc-integration.md](references/acc-integration.md).
+
+### 7) React app supports modern web APIs and npm only
+
+Inside a React UI bundle these are **not supported**:
+
+- `@salesforce/*` scoped modules **except** `@salesforce/sdk-data` (and the ACC and `@salesforce/ui-bundle` helpers)
+- Lightning base components / `lightning/*` modules
+- `@wire` service
+
+If you need those, build an LWC instead.
+
+### 8) Beta limitations
+
+- Sandbox and scratch orgs only.
+- Default language must be `en_US`.
+- DE orgs and Trailhead Playgrounds are **not supported**.
+- Once Multi-Framework is enabled in an org, it **cannot be disabled**.
+
+---
+
+## Recommended Authoring Workflow
+
+### Phase 1 — Org & environment setup
+- enable **Salesforce Multi-Framework (Beta)** in Setup
+- install Node 22+, latest `sf` CLI, Salesforce Extension Pack, `@salesforce/plugin-ui-bundle-dev`
+- for external apps: enable Digital Experiences, create a placeholder site, confirm Customer/Partner Community licenses
+- for ACC: configure My Domain cookies, Trusted Domains for Inline Frames, and Agentforce preference
+- full sequence: [references/setup.md](references/setup.md)
+
+### Phase 2 — Scaffold the project
+
+```bash
+# Inside an existing DX project
+sf template generate ui-bundle --name myApp --template reactinternalapp
+# or for B2B/B2C portals
+sf template generate ui-bundle --name myApp --template reactexternalapp
+
+# Or scaffold a brand-new DX project + external app
+sf template generate project --template reactexternalapp
+```
+
+Templates: [references/templates.md](references/templates.md). Project layout: [references/project-structure.md](references/project-structure.md).
+
+### Phase 3 — Local development
+
+```bash
+cd force-app/main/default/uiBundles/myApp
+npm install
+npm run graphql:schema     # introspect connected org
+npm run graphql:codegen    # generate src/api/graphql-operations-types.ts
+npm run dev                # Vite dev server with @salesforce/vite-plugin-ui-bundle
+```
+
+Dev server URL must be added to **Trusted Domains for Inline Frames** if you use ACC locally.
+
+### Phase 4 — Build and deploy
+
+```bash
+npm run build                         # tsc -b && vite build → dist/
+cd ../../../../..                     # back to project root
+sf project deploy start \
+  --source-dir force-app/main/default/uiBundles/myApp \
+  --target-org TARGET_ORG
+```
+
+Preference: deploy via the **Salesforce DX MCP** (`mcp_Salesforce_DX_deploy_metadata`) if available; CLI is the fallback.
+
+### Phase 5 — Verify in org
+
+- Open the org: `sf org open` → App Launcher → your app (internal) or Digital Experiences (external).
+- Confirm SPA refresh works on a deep route.
+- For ACC: confirm the FAB appears, the panel opens, and Lightning Types render.
+
+---
+
+## Data Access — The Three Patterns
+
+### Pattern A — Inline `gql` (simple queries)
+
+Best for recipes / single-component reads. The lesson is visible in the file.
+
+```tsx
+import { createDataSDK, gql } from "@salesforce/sdk-data";
+
+const QUERY = gql`
+  query SingleAccount {
+    uiapi {
+      query {
+        Account(first: 1) {
+          edges { node { Id Name { value } Industry { value } } }
+        }
+      }
+    }
+  }
+`;
+
+const sdk = await createDataSDK();
+const res = await sdk.graphql?.(QUERY);
+```
+
+### Pattern B — External `.graphql` + codegen (complex/shared queries)
+
+```
+src/api/utils/query/singleAccountQuery.graphql
+src/api/graphql-operations-types.ts        # generated
+src/api/graphqlClient.ts                    # executeGraphQL wrapper
+```
+
+Use when the query has variables, fragments, or is shared across components. Run `npm run graphql:codegen` after every edit.
+
+### Pattern C — `sdk.fetch?.()` for REST
+
+For UI API REST or Apex REST that GraphQL can't express. Allow-list and patterns: [references/data-sdk.md](references/data-sdk.md).
+
+---
+
+## Error Handling — Three Strategies
+
+GraphQL can return `data` AND `errors` in the same response. Pick the strategy per call site:
+
+| Strategy | When to use |
+|---|---|
+| **Strict** — fail on any error | data integrity matters; partial data is misleading |
+| **Tolerant** — log errors, use partial data | optional fields; UI degrades gracefully |
+| **Permissive** — only fail when no data at all | mutations that succeed but can't read back every field |
+
+For `sdk.fetch?.()` errors: wrap transport errors, then check HTTP status, then handle 401 / 403 with sign-in / permission flows. Full patterns: [references/error-handling.md](references/error-handling.md).
+
+---
+
+## Styling — Three Approaches
+
+| Approach | Use when |
+|---|---|
+| **SLDS blueprints** (CSS classes) | You want native Salesforce look, full markup control, latest SLDS not auto-applied |
+| **`@salesforce/design-system-react`** | You want SLDS components and accept an older pinned SLDS CSS |
+| **Tailwind + shadcn/ui** | You want a custom branded look or are building a fresh design system |
+
+You can mix at the **app shell** vs **recipe/page** boundary, but **don't mix inside one component** — pick one system per component. Tokens, dark mode, and SLDS focus-ring color guidance: [references/styling.md](references/styling.md).
+
+---
+
+## ACC Integration — Quick Path
+
+1. Confirm prerequisites in [references/acc-integration.md](references/acc-integration.md) (Employee Agent, cookies, Trusted Domains, Agentforce preference).
+2. Add the package: `npm install @salesforce/agentforce-conversation-client`.
+3. Mount via `createAccWidget` inside a `useEffect` keyed off a `useRef` container.
+4. Configure dock/floating/inline mode and styling tokens via SDK options.
+5. For pure programmatic open/close from inside a custom LWC (no React), use the ACC API instead of this skill.
+
+---
+
+## Cross-Skill Orchestration
+
+| Task | Delegate to |
+|---|---|
+| Build Apex REST / Apex controllers called by the app | [sf-apex](../sf-apex/SKILL.md) |
+| Author or fix the Employee Agent that ACC connects to | [sf-ai-agentforce](../sf-ai-agentforce/SKILL.md) or [sf-ai-agentscript](../sf-ai-agentscript/SKILL.md) |
+| Test the Employee Agent | [sf-ai-agentforce-testing](../sf-ai-agentforce-testing/SKILL.md) |
+| Permission sets / profiles for the bundle | [sf-permissions](../sf-permissions/SKILL.md) |
+| Deploy at scale / CI | [sf-deploy](../sf-deploy/SKILL.md) |
+| SOQL helpers for Apex backing the app | [sf-soql](../sf-soql/SKILL.md) |
+
+---
+
+## High-Signal Failure Patterns
+
+| Symptom | Likely cause | Read next |
+|---|---|---|
+| Hard refresh on a sub-route returns 404 | `routing.fallback` not set to `index.html` | [references/project-structure.md](references/project-structure.md) |
+| Local dev fetches succeed, deployed fetches 401/403 | bypassing Data SDK or hitting non-allowlisted endpoint | [references/data-sdk.md](references/data-sdk.md) |
+| `Cannot read properties of undefined (reading 'value')` on GraphQL data | forgetting the UI API `{ value }` field wrapper | [references/data-sdk.md](references/data-sdk.md), [references/graphql-workflow.md](references/graphql-workflow.md) |
+| Codegen produces no types | `schema.graphql` missing — never ran `npm run graphql:schema` | [references/graphql-workflow.md](references/graphql-workflow.md) |
+| ACC FAB never appears | Trusted Domains not registered, or "Require first-party Salesforce cookies" still on | [references/acc-integration.md](references/acc-integration.md) |
+| ACC loads but disconnects on navigation | cookie policy / iframe origin mismatch | [references/acc-integration.md](references/acc-integration.md) |
+| External app deploys but never appears in Digital Experiences | `appContainer: true` or `appSpace` not set, or namespace prefix wrong | [references/templates.md](references/templates.md) |
+| Mutation succeeds but read-back errors | UI API mutation return shape can't include some fields — switch to Permissive error strategy | [references/error-handling.md](references/error-handling.md) |
+| Build succeeds but deploy fails with file count error | UIBundle 2,500-file limit; prune `dist/` source maps or unused assets | [references/troubleshooting.md](references/troubleshooting.md) |
+| `sf template generate ui-bundle` is not recognized | `@salesforce/plugin-ui-bundle-dev` not installed | [references/cli-guide.md](references/cli-guide.md) |
+| Beta toggle missing in Setup | org is DE / Playground (not supported), or default language ≠ `en_US` | [references/setup.md](references/setup.md) |
+| Navigation works locally, breaks in Lightning Experience | `basename` not derived from `SFDC_ENV.basePath` | [references/react-router.md](references/react-router.md) |
+| Build error: "no exported member BrowserRouter" | importing from `react-router-dom` instead of `react-router` (v7) | [references/react-router.md](references/react-router.md) |
+| Image / font / analytics blocked with CSP console error | missing `CspTrustedSite` metadata | [references/permissions-csp.md](references/permissions-csp.md) |
+| Field value is always `null` in production | FLS / object permissions missing in the user's permission set | [references/permissions-csp.md](references/permissions-csp.md) |
+| `axe` tests throw `getContext is not a function` | `vitest.setup.ts` missing the jsdom `HTMLCanvasElement` stub | [references/testing.md](references/testing.md) |
+| Scratch org deploy fails with feature-not-enabled | scratch def missing `UIBundleSettings.webAppOptIn: true` | [references/ci-deploy.md](references/ci-deploy.md) |
+
+---
+
+## Reference Map
+
+### Start here
+- [references/activation-checklist.md](references/activation-checklist.md)
+- [references/overview.md](references/overview.md)
+- [references/setup.md](references/setup.md)
+
+### Project mechanics
+- [references/project-structure.md](references/project-structure.md)
+- [references/templates.md](references/templates.md)
+- [references/cli-guide.md](references/cli-guide.md)
+
+### Data access
+- [references/data-sdk.md](references/data-sdk.md)
+- [references/graphql-workflow.md](references/graphql-workflow.md)
+- [references/error-handling.md](references/error-handling.md)
+
+### UI / experience
+- [references/styling.md](references/styling.md)
+- [references/acc-integration.md](references/acc-integration.md)
+- [references/recipe-conventions.md](references/recipe-conventions.md)
+- [references/react-router.md](references/react-router.md)
+
+### Security & access
+- [references/permissions-csp.md](references/permissions-csp.md)
+
+### Testing & delivery
+- [references/testing.md](references/testing.md)
+- [references/ci-deploy.md](references/ci-deploy.md)
+
+### Authoring surface
+- [references/authoring-surface.md](references/authoring-surface.md)
+
+### Decisions & troubleshooting
+- [references/lwc-vs-react.md](references/lwc-vs-react.md)
+- [references/troubleshooting.md](references/troubleshooting.md)
+- [references/scoring-rubric.md](references/scoring-rubric.md)
+- [references/official-sources.md](references/official-sources.md)
+
+### Examples / scaffolds
+- [assets/templates/](assets/templates/)
+- [assets/examples/](assets/examples/)
+
+---
+
+## Score Guide
+
+| Score | Meaning |
+|---|---|
+| 90+ | Deploy with confidence |
+| 75–89 | Good, review warnings |
+| 60–74 | Needs focused revision |
+| < 60 | Block deploy |
+
+Full rubric: [references/scoring-rubric.md](references/scoring-rubric.md)
+
+---
+
+## Official Resources
+
+- [Build a React App with Salesforce Multi-Framework (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-overview.html)
+- [Configure Your Org for React Development (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-setup.html)
+- [Integrate Your React App with the Agentforce 360 Platform (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-integrate.html)
+- [Develop a React App Manually (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-develop.html)
+- [Data SDK and GraphQL (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-data-sdk.html)
+- [Access Record Data with Data SDK (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-data-sdk-usage.html)
+- [Error Handling in Data SDK (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-data-sdk-graphql-error.html)
+- [Style Your React Apps (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-styling.html)
+- [Integrate Agentforce Conversation Client (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-acc.html)
+- [React vs LWC (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-lwc-diff.html)
+- [Multi-Framework Recipes (GitHub)](https://github.com/trailheadapps/multiframework-recipes)

--- a/skills/sf-multiframework/assets/README.md
+++ b/skills/sf-multiframework/assets/README.md
@@ -9,7 +9,7 @@ Drop-in metadata + config files for a Multi-Framework UI bundle.
 | File | Use |
 |---|---|
 | `myApp.uibundle-meta.xml` | UIBundle metadata. Rename file to match your `--name`. Update `<masterLabel>` and `<target>`. |
-| `ui-bundle.json` | Runtime configuration with SPA fallback. Adjust `apiVersion` to match your org. |
+| `ui-bundle.json` | Runtime configuration with SPA fallback. Keep top-level keys to `outputDir`, `routing`, and `headers`. |
 | `external-content.json` | `digitalExperiences/sfdc_cms_site/content.json` for external (`Experience`-target) apps. Update `appSpace` to `c__<DeveloperName>` (or `<Namespace>__<DeveloperName>`). |
 | `vite.config.ts` | Minimal Vite config with `@salesforce/vite-plugin-ui-bundle` and path aliases. |
 | `codegen.yml` | GraphQL codegen config with full UIAPI scalar mappings. Drop into the bundle root. |

--- a/skills/sf-multiframework/assets/README.md
+++ b/skills/sf-multiframework/assets/README.md
@@ -1,0 +1,39 @@
+# sf-multiframework — Asset Reference
+
+Reference files used by the skill. **Copy and adapt** — these are minimal starters, not full-featured templates.
+
+## `templates/`
+
+Drop-in metadata + config files for a Multi-Framework UI bundle.
+
+| File | Use |
+|---|---|
+| `myApp.uibundle-meta.xml` | UIBundle metadata. Rename file to match your `--name`. Update `<masterLabel>` and `<target>`. |
+| `ui-bundle.json` | Runtime configuration with SPA fallback. Adjust `apiVersion` to match your org. |
+| `external-content.json` | `digitalExperiences/sfdc_cms_site/content.json` for external (`Experience`-target) apps. Update `appSpace` to `c__<DeveloperName>` (or `<Namespace>__<DeveloperName>`). |
+| `vite.config.ts` | Minimal Vite config with `@salesforce/vite-plugin-ui-bundle` and path aliases. |
+| `codegen.yml` | GraphQL codegen config with full UIAPI scalar mappings. Drop into the bundle root. |
+
+## `examples/`
+
+Reference React + GraphQL code patterns.
+
+| File | Demonstrates |
+|---|---|
+| `SingleRecord.tsx` | Recipe-style inline `gql` + `{ value }` UIAPI shape + Loading / Error / Loaded states |
+| `graphqlClient.ts` | Production-style Strict / Tolerant / Permissive wrappers around `sdk.graphql?.()` |
+| `listAccountsQuery.graphql` | External-file pattern with variables + connection pagination |
+| `AccChatPanel.tsx` | Minimal Agentforce Conversation Client mount with `useRef` + cleanup |
+| `global.css` | Tailwind / shadcn design-token entry point with Salesforce-blue focus ring + dark mode |
+
+## What's intentionally not here
+
+- A full LWR `digitalExperiences` bundle — too org-specific; use `sf template generate ui-bundle --template reactexternalapp`.
+- Complete `package.json` for the bundle — versions move too fast; use the template scaffold.
+- ESLint config — the templates ship a flat config that's well-tuned to React 19 + GraphQL ESLint plugin.
+
+## How to use
+
+1. Scaffold via `sf template generate ui-bundle` first (preferred).
+2. Use these files when you need to **understand** what the scaffold did, or when you need to **add** something to a manually-built bundle.
+3. Always cross-check against [`trailheadapps/multiframework-recipes`](https://github.com/trailheadapps/multiframework-recipes) for the current canonical pattern.

--- a/skills/sf-multiframework/assets/examples/AccChatPanel.tsx
+++ b/skills/sf-multiframework/assets/examples/AccChatPanel.tsx
@@ -1,0 +1,48 @@
+/**
+ * Agentforce Conversation Client (ACC) — minimal mount.
+ *
+ * Prerequisites in Setup (see references/acc-integration.md):
+ *   - Agentforce preference enabled, Employee Agent configured
+ *   - My Domain: "Require first-party use of Salesforce cookies" UNCHECKED
+ *   - Session Settings → Trusted Domains for Inline Frames includes this app's
+ *     origin (prod, preview, AND http://localhost:<port>) with iFrame type Lightning Out
+ *
+ * Install:
+ *   npm install @salesforce/agentforce-conversation-client
+ *
+ * NOTE: The exact `createAccWidget` option shape evolves with the package
+ *       version. Always check the installed version's TypeScript declarations.
+ */
+
+import { useEffect, useRef } from "react";
+import { createAccWidget } from "@salesforce/agentforce-conversation-client";
+
+interface Props {
+  mode?: "floating" | "docked" | "inline";
+}
+
+export function AccChatPanel({ mode = "floating" }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetRef = useRef<{ destroy: () => void } | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    widgetRef.current = createAccWidget({
+      container: containerRef.current,
+      mode,
+      welcomeMessage: "How can I help today?",
+      brand: {
+        primaryColor: "#0176d3",
+        borderRadius: "0.5rem"
+      }
+    });
+
+    return () => {
+      widgetRef.current?.destroy();
+      widgetRef.current = null;
+    };
+  }, [mode]);
+
+  return <div ref={containerRef} className="acc-host" />;
+}

--- a/skills/sf-multiframework/assets/examples/SingleRecord.tsx
+++ b/skills/sf-multiframework/assets/examples/SingleRecord.tsx
@@ -1,0 +1,83 @@
+/**
+ * Recipe: Single Record
+ *
+ * Queries a single Account by ID using the Data SDK.
+ * Demonstrates the inline gql pattern and the { value } UIAPI shape.
+ */
+
+import { useEffect, useState } from "react";
+import { createDataSDK, gql } from "@salesforce/sdk-data";
+
+const QUERY = gql`
+  query SingleAccount {
+    uiapi {
+      query {
+        Account(first: 1) {
+          edges {
+            node {
+              Id
+              Name { value }
+              Industry { value }
+              BillingCity { value }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface AccountFields {
+  id: string;
+  name: string;
+  industry: string | null;
+  city: string | null;
+}
+
+export default function SingleRecord() {
+  const [account, setAccount] = useState<AccountFields | undefined>();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const sdk = await createDataSDK();
+        const res = await sdk.graphql?.(QUERY);
+        // UI API wraps every field in { value } — this is Salesforce-specific.
+        const node = res?.data?.uiapi?.query?.Account?.edges?.[0]?.node;
+        if (node) {
+          setAccount({
+            id: node.Id,
+            name: node.Name?.value ?? "—",
+            industry: node.Industry?.value ?? null,
+            city: node.BillingCity?.value ?? null
+          });
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Request failed");
+      }
+    })();
+  }, []);
+
+  if (error) return <ErrorState message={error} />;
+  if (!account) return <Skeleton />;
+  return <AccountTile account={account} />;
+}
+
+function Skeleton() {
+  return <div className="slds-card slds-is-loading">Loading…</div>;
+}
+
+function ErrorState({ message }: { message: string }) {
+  return <div className="slds-text-color_error">{message}</div>;
+}
+
+function AccountTile({ account }: { account: AccountFields }) {
+  return (
+    <article className="slds-card slds-p-around_medium">
+      <h2 className="slds-text-heading_small">{account.name}</h2>
+      <p>{account.industry ?? "Unknown industry"}</p>
+      {account.city && <p className="slds-text-body_small">{account.city}</p>}
+    </article>
+  );
+}

--- a/skills/sf-multiframework/assets/examples/global.css
+++ b/skills/sf-multiframework/assets/examples/global.css
@@ -1,0 +1,62 @@
+/**
+ * Design system entry point.
+ *
+ * - Tailwind 4 + shadcn token wiring
+ * - Salesforce-blue focus ring for native-feel components
+ * - Dark mode via .dark class on <html>
+ *
+ * See references/styling.md for the full pattern.
+ */
+
+@import "tailwindcss";
+
+@layer base {
+  body {
+    @apply min-h-screen antialiased text-foreground bg-background;
+  }
+  *:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+  }
+}
+
+:root {
+  --color-background: oklch(1 0 0);
+  --color-foreground: oklch(0.145 0 0);
+  --color-primary:    oklch(0.205 0 0);
+  --color-primary-foreground: oklch(0.985 0 0);
+  --color-secondary:  oklch(0.97 0 0);
+  --color-secondary-foreground: oklch(0.205 0 0);
+  --color-muted:      oklch(0.97 0 0);
+  --color-muted-foreground: oklch(0.556 0 0);
+  --color-border:     oklch(0.922 0 0);
+  --color-input:      oklch(0.922 0 0);
+  --radius:           0.5rem;
+  --ring:             #0176d3;   /* Salesforce blue */
+}
+
+.dark {
+  --color-background: oklch(0.145 0 0);
+  --color-foreground: oklch(0.985 0 0);
+  --color-primary:    oklch(0.985 0 0);
+  --color-primary-foreground: oklch(0.205 0 0);
+  --color-secondary:  oklch(0.269 0 0);
+  --color-secondary-foreground: oklch(0.985 0 0);
+  --color-muted:      oklch(0.269 0 0);
+  --color-muted-foreground: oklch(0.708 0 0);
+  --color-border:     oklch(0.269 0 0);
+}
+
+@theme inline {
+  --color-background:           var(--color-background);
+  --color-foreground:           var(--color-foreground);
+  --color-primary:              var(--color-primary);
+  --color-primary-foreground:   var(--color-primary-foreground);
+  --color-secondary:            var(--color-secondary);
+  --color-secondary-foreground: var(--color-secondary-foreground);
+  --color-muted:                var(--color-muted);
+  --color-muted-foreground:     var(--color-muted-foreground);
+  --color-border:               var(--color-border);
+  --color-input:                var(--color-input);
+  --radius:                     var(--radius);
+}

--- a/skills/sf-multiframework/assets/examples/graphqlClient.ts
+++ b/skills/sf-multiframework/assets/examples/graphqlClient.ts
@@ -1,0 +1,91 @@
+/**
+ * Strict-by-default GraphQL wrapper around the Data SDK.
+ *
+ * Use this for production code that wants type-safe call sites.
+ * Recipes should use inline gql + sdk.graphql?.() directly so the lesson
+ * is visible in the recipe file.
+ *
+ * Strategy variants (see references/error-handling.md):
+ *   - Strict      — fail on any error
+ *   - Tolerant    — log errors, return partial data
+ *   - Permissive  — only fail when no data at all (mutations)
+ */
+
+import { createDataSDK } from "@salesforce/sdk-data";
+export { gql } from "@salesforce/sdk-data";
+
+let sdkPromise: ReturnType<typeof createDataSDK> | null = null;
+
+function getSdk() {
+  if (!sdkPromise) {
+    sdkPromise = createDataSDK({
+      webapp: {
+        on401: () => {
+          // Customize: refresh session, redirect to login, etc.
+          console.warn("Session expired (401)");
+        },
+        on403: () => {
+          console.warn("Insufficient permissions (403)");
+        }
+      }
+    });
+  }
+  return sdkPromise;
+}
+
+export async function executeGraphQL<TData, TVars = Record<string, unknown>>({
+  query,
+  variables
+}: {
+  query: string;
+  variables?: TVars;
+}): Promise<TData> {
+  const sdk = await getSdk();
+  const response = await sdk.graphql?.(query, variables);
+
+  if (!response) {
+    throw new Error("GraphQL surface unavailable in this environment");
+  }
+  if (response.errors?.length) {
+    throw new Error(response.errors.map((e: { message: string }) => e.message).join("; "));
+  }
+  return response.data as TData;
+}
+
+export async function executeGraphQLTolerant<TData, TVars = Record<string, unknown>>({
+  query,
+  variables
+}: {
+  query: string;
+  variables?: TVars;
+}): Promise<TData> {
+  const sdk = await getSdk();
+  const response = await sdk.graphql?.(query, variables);
+
+  if (!response?.data) {
+    throw new Error("No data returned");
+  }
+  if (response.errors?.length) {
+    console.warn("GraphQL partial errors:", response.errors);
+  }
+  return response.data as TData;
+}
+
+export async function executeGraphQLPermissive<TData, TVars = Record<string, unknown>>({
+  query,
+  variables
+}: {
+  query: string;
+  variables?: TVars;
+}): Promise<TData> {
+  const sdk = await getSdk();
+  const response = await sdk.graphql?.(query, variables);
+
+  if (!response) {
+    throw new Error("GraphQL surface unavailable");
+  }
+  if (!response.data && response.errors?.length) {
+    throw new Error(response.errors.map((e: { message: string }) => e.message).join("; "));
+  }
+  return response.data as TData;
+}

--- a/skills/sf-multiframework/assets/examples/listAccountsQuery.graphql
+++ b/skills/sf-multiframework/assets/examples/listAccountsQuery.graphql
@@ -1,0 +1,25 @@
+query ListAccounts($first: Int = 20, $after: String) {
+  uiapi {
+    query {
+      Account(
+        first: $first
+        after: $after
+        orderBy: { Name: { order: ASC } }
+      ) {
+        edges {
+          node {
+            Id
+            Name { value }
+            Industry { value }
+            BillingCity { value }
+            AnnualRevenue { value }
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }
+  }
+}

--- a/skills/sf-multiframework/assets/templates/codegen.yml
+++ b/skills/sf-multiframework/assets/templates/codegen.yml
@@ -1,0 +1,27 @@
+schema: ./schema.graphql
+documents:
+  - "src/**/*.graphql"
+  - "src/**/*.ts"
+  - "src/**/*.tsx"
+generates:
+  src/api/graphql-operations-types.ts:
+    plugins:
+      - typescript
+      - typescript-operations
+    config:
+      avoidOptionals: false
+      skipTypename: false
+      scalars:
+        Currency: string
+        Date: string
+        DateTime: string
+        Email: string
+        EncryptedString: string
+        Long: number
+        MultiPicklist: string
+        Percent: number
+        Phone: string
+        Picklist: string
+        TextArea: string
+        Time: string
+        Url: string

--- a/skills/sf-multiframework/assets/templates/external-content.json
+++ b/skills/sf-multiframework/assets/templates/external-content.json
@@ -1,0 +1,4 @@
+{
+  "appContainer": true,
+  "appSpace": "c__myPortal"
+}

--- a/skills/sf-multiframework/assets/templates/myApp.uibundle-meta.xml
+++ b/skills/sf-multiframework/assets/templates/myApp.uibundle-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<UIBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <isActive>true</isActive>
+    <masterLabel>My App</masterLabel>
+    <target>AppLauncher</target>
+    <version>1.0.0</version>
+</UIBundle>

--- a/skills/sf-multiframework/assets/templates/ui-bundle.json
+++ b/skills/sf-multiframework/assets/templates/ui-bundle.json
@@ -1,0 +1,9 @@
+{
+  "outputDir": "dist",
+  "apiVersion": "v66.0",
+  "routing": {
+    "fileBasedRouting": true,
+    "trailingSlash": "never",
+    "fallback": "index.html"
+  }
+}

--- a/skills/sf-multiframework/assets/templates/ui-bundle.json
+++ b/skills/sf-multiframework/assets/templates/ui-bundle.json
@@ -1,6 +1,5 @@
 {
   "outputDir": "dist",
-  "apiVersion": "v66.0",
   "routing": {
     "fileBasedRouting": true,
     "trailingSlash": "never",

--- a/skills/sf-multiframework/assets/templates/vite.config.ts
+++ b/skills/sf-multiframework/assets/templates/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { uiBundle } from "@salesforce/vite-plugin-ui-bundle";
+import path from "node:path";
+
+// Minimal Vite config for a Salesforce Multi-Framework UI bundle.
+// The @salesforce/vite-plugin-ui-bundle integration proxies Salesforce
+// API calls during dev so @salesforce/sdk-data works against a real org.
+
+export default defineConfig({
+  plugins: [react(), uiBundle()],
+  resolve: {
+    alias: {
+      "@":           path.resolve(__dirname, "src"),
+      "@api":        path.resolve(__dirname, "src/api"),
+      "@components": path.resolve(__dirname, "src/components"),
+      "@utils":      path.resolve(__dirname, "src/utils"),
+      "@styles":     path.resolve(__dirname, "src/styles"),
+      "@assets":     path.resolve(__dirname, "src/assets")
+    }
+  },
+  build: {
+    outDir: "dist",
+    sourcemap: false
+  }
+});

--- a/skills/sf-multiframework/references/acc-integration.md
+++ b/skills/sf-multiframework/references/acc-integration.md
@@ -1,0 +1,152 @@
+# Agentforce Conversation Client (ACC) Integration
+
+ACC is a **Lightning Web Component Interface (LWCI)** built on Lightning Out 2.0. It embeds an Agentforce **Employee Agent** chat UI inside a non-LWC host (your React app). It handles streaming, dynamic Lightning Type rendering, and brand styling.
+
+> ACC for **internal apps** (employee use cases) is the path documented here. For external customer-facing apps, refer to the standalone *Agentforce Conversation Client Developer Guide*. For programmatic open/close inside a custom LWC (no React), use the ACC API directly.
+
+## Why use ACC
+
+- Drop-in chat container — no rebuild from scratch
+- Token-by-token streaming infrastructure included
+- **Dynamic Lightning Type rendering** — input/output/list/picklist UI components rendered on the fly based on agent responses
+- Brand styling hooks (fonts, colors, borders, spacing, component substitutions)
+- Cross-framework — embed in any non-LWC stack
+- Lets you ship "write once, deploy anywhere" UX (Service Cloud, public site, or React app)
+
+## Prerequisites
+
+### 1. Org-side configuration
+
+| Setting | Path | Action |
+|---|---|---|
+| Agentforce preference | Setup → Einstein → Einstein Generative AI → Agentforce Studio → Agentforce Agents | **Enable** |
+| Employee Agent | Same area | At least one configured with topics + actions |
+| Cookie policy | Setup → My Domain → Routing and Policies | **Uncheck** *Require first-party use of Salesforce cookies* |
+| Trusted Domains for Inline Frames | Setup → Session Settings | Add prod URL **and** local dev URL (e.g. `http://localhost:5173`), iFrame type **Lightning Out** |
+
+Skipping any of these is the #1 cause of "FAB doesn't appear" or "panel disconnects on navigation" errors.
+
+### 2. Project-side dependencies
+
+```bash
+cd force-app/main/default/uiBundles/myApp
+npm install @salesforce/agentforce-conversation-client
+```
+
+## Two integration paths
+
+### Path A — Agentforce Vibes (natural-language scaffolding)
+
+If you're using VS Code with Agentforce Vibes:
+
+1. Open the Vibes panel and confirm the Salesforce skills + rules are enabled.
+2. Confirm your DX project has the standard structure (see [project-structure.md](project-structure.md)).
+3. Use natural-language prompts:
+
+> "Create an Agentforce Employee Agent panel that is docked to the right of the main screen."
+
+> "The Agentforce Employee Agent panel should start as a floating FAB icon docked to the lower left of the page; when a user clicks the icon, it should expand into a full chat panel."
+
+Vibes manipulates `index.tsx`, installs npm dependencies, and configures dock/floating/inline modes for you.
+
+### Path B — Manual integration
+
+Use `createAccWidget` from the package directly, with a `useRef` container and `useEffect` lifecycle.
+
+```tsx
+import { useEffect, useRef } from "react";
+import { createAccWidget } from "@salesforce/agentforce-conversation-client";
+
+export function ChatPanel() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetRef = useRef<{ destroy: () => void } | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    widgetRef.current = createAccWidget({
+      container: containerRef.current,
+      mode: "floating",                 // or "inline" / "docked"
+      welcomeMessage: "How can I help today?",
+      brand: {
+        primaryColor: "#0176d3",
+        borderRadius: "0.5rem"
+      }
+      // additional SDK style tokens supported per official docs
+    });
+
+    return () => {
+      widgetRef.current?.destroy();
+    };
+  }, []);
+
+  return <div ref={containerRef} className="acc-host" />;
+}
+```
+
+> The exact `createAccWidget` option shape evolves with the package. Always check the installed `@salesforce/agentforce-conversation-client` version's TypeScript declarations or README for the current API.
+
+## Display modes
+
+| Mode | Behavior | Use case |
+|---|---|---|
+| **Floating** | Default. FAB icon → expands to chat panel | Single-page apps where chat is secondary |
+| **Docked** | Persistent panel attached to a side of the viewport | Apps where chat is a primary surface |
+| **Inline** | Renders inside a designated parent container | Embedding chat as a section of a dashboard |
+
+## What ACC handles for you
+
+| Capability | What it does |
+|---|---|
+| **Streaming** | Token-by-token rendering, progress status indicators, low perceived latency |
+| **Lightning Types** | Auto-maps `lightning__textType`, custom Lightning Types, etc. to the right UI renderer |
+| **Dynamic rendering** | Constructs UI components in real time based on agent planner output |
+| **Branding** | SDK exposes style tokens (header color, message block colors, fonts, radii) |
+| **Welcome message** | Configurable "secure connection" confirmation when the panel opens |
+| **Inline rich UI** | Cards, lists, form-style inputs (e.g. flight booking, property listings) rendered directly in the conversation |
+
+## Integration checklist
+
+- [ ] Agentforce preference is **enabled** in Setup
+- [ ] At least one Employee Agent with topics + actions exists
+- [ ] My Domain → "Require first-party use of Salesforce cookies" is **off**
+- [ ] Session Settings → Trusted Domains for Inline Frames includes both prod and local dev origins
+- [ ] iFrame type for those domains is **Lightning Out**
+- [ ] `@salesforce/agentforce-conversation-client` installed
+- [ ] Mount uses `useRef` for the container element
+- [ ] Mount runs in `useEffect` and **cleans up** in the return function
+- [ ] If using Vibes, all Salesforce MCP servers and skills are enabled
+- [ ] Smoke-test: FAB appears, panel opens, agent connects, Lightning Types render
+
+## Common ACC failure patterns
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| FAB never appears | Trusted Domain not added, or cookies still restricted | Verify both Setup steps; ensure iFrame type is Lightning Out |
+| Panel opens but agent disconnects on nav | Origin mismatch between deployed app and Trusted Domain entry | Add the exact origin (`https://app.example.com`, including port if non-standard) |
+| Welcome message missing | Agentforce preference disabled | Setup → Einstein → enable Agentforce |
+| Rich Lightning Types render as plain text | Agent action output not configured to use a Lightning Type | Update GenAiFunction output schema (delegate to sf-ai-agentforce) |
+| Streaming stutters / cuts off | Network instability — ACC handles this, but logs help | Inspect browser devtools → Network → keepalive |
+| Chat panel state lost on React re-render | Widget destroyed/recreated | Memoize the container, only recreate when mount key changes |
+| Branding doesn't apply | SDK style tokens passed wrong key names | Check installed package version's docs for current option names |
+
+## Local dev specifics
+
+- The Vite dev server origin (default `http://localhost:5173`) **must** be added to Trusted Domains for Inline Frames.
+- Restart the dev server after adding the domain in Salesforce — the iframe needs a fresh load.
+- ACC will not work in `localhost` until *both* the cookie policy AND trusted domain entries are in place.
+
+## What to do when ACC isn't right
+
+| Need | Use instead |
+|---|---|
+| External-facing customer chat | Standalone Agentforce Conversation Client (separate guide) |
+| Programmatic open/close inside a custom LWC | ACC API directly |
+| Chat with a Service Agent (not Employee) | Different ACC flavor — check the standalone guide |
+| Custom UI for agent output you fully control | Build the agent action with a custom Lightning Type and a custom LWC renderer (delegate to sf-ai-agentforce / sf-lwc) |
+
+## See also
+
+- [Integrate ACC in a React App (official Beta docs)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-acc.html)
+- [setup.md](setup.md) — full org configuration sequence
+- Lightning Types in Agent Action — official Salesforce docs

--- a/skills/sf-multiframework/references/activation-checklist.md
+++ b/skills/sf-multiframework/references/activation-checklist.md
@@ -19,7 +19,8 @@ Run through this list before authoring or fixing a Multi-Framework app. Each ite
 - [ ] `<appName>.uibundle-meta.xml` exists at the bundle root
 - [ ] `ui-bundle.json` exists at the bundle root
 - [ ] `outputDir` in `ui-bundle.json` matches what the build emits (Vite default: `dist`)
-- [ ] `apiVersion` matches the target org (e.g. `"v66.0"`)
+- [ ] `ui-bundle.json` contains only supported top-level keys: `outputDir`, `routing`, `headers`
+- [ ] API version is set through `sfdx-project.json` / deploy API version, not `ui-bundle.json`
 - [ ] For SPAs: `routing.fallback: "index.html"` is set
 - [ ] `package.json` inside the bundle (separate from the project root `package.json`)
 
@@ -68,6 +69,7 @@ Run through this list before authoring or fixing a Multi-Framework app. Each ite
 - [ ] `npm run lint` passes
 - [ ] `npm run build` passes (this is the artifact that ships)
 - [ ] `dist/` size is sane and < 2,500 files (UIBundle ceiling)
+- [ ] Build script does not emit TypeScript side artifacts at the bundle root (`*.tsbuildinfo`, `vite.config.js`, `vite.config.d.ts`)
 - [ ] Deploy via `sf project deploy start --source-dir force-app/main/default/uiBundles/<appName>` (or MCP equivalent)
 - [ ] Smoke-test: open the app in App Launcher (internal) or Digital Experiences (external)
 - [ ] Smoke-test: hard-refresh on a deep route — should not 404

--- a/skills/sf-multiframework/references/activation-checklist.md
+++ b/skills/sf-multiframework/references/activation-checklist.md
@@ -1,0 +1,81 @@
+# Activation Checklist
+
+Run through this list before authoring or fixing a Multi-Framework app. Each item maps to a common failure mode.
+
+## Org & Environment
+
+- [ ] Org is **Sandbox** or **Scratch** (DE / Playgrounds unsupported in Beta)
+- [ ] Org default language is **`en_US`** (scratch org def explicitly sets `"language": "en_US"`)
+- [ ] **Salesforce Multi-Framework (Beta)** enabled in Setup → cannot be disabled later
+- [ ] User has **Customize Application** permission to enable the feature
+- [ ] **Node.js v22+** installed (`node -v`)
+- [ ] **Salesforce CLI** is current (`sf update`)
+- [ ] **`@salesforce/plugin-ui-bundle-dev`** installed (`sf plugins`)
+- [ ] **Salesforce Extension Pack** installed in VS Code (or equivalent IDE)
+
+## Project Layout
+
+- [ ] App lives at `force-app/main/default/uiBundles/<appName>/` (or matching package dir)
+- [ ] `<appName>.uibundle-meta.xml` exists at the bundle root
+- [ ] `ui-bundle.json` exists at the bundle root
+- [ ] `outputDir` in `ui-bundle.json` matches what the build emits (Vite default: `dist`)
+- [ ] `apiVersion` matches the target org (e.g. `"v66.0"`)
+- [ ] For SPAs: `routing.fallback: "index.html"` is set
+- [ ] `package.json` inside the bundle (separate from the project root `package.json`)
+
+## External Apps Only (`target: Experience`)
+
+- [ ] **Digital Experiences** is enabled in Setup
+- [ ] At least one site exists (placeholder is fine — no template needed)
+- [ ] Customer/Partner Community user licenses available
+- [ ] `digitalExperienceConfigs/` deployed
+- [ ] `digitalExperiences/sfdc_cms_site/` deployed with `content.json` having:
+  - `appContainer: true`
+  - `appSpace: "<NamespacePrefix>__<DeveloperName>"` (or `c__<DeveloperName>` if no namespace)
+- [ ] `networks/` and `sites/` deployed
+- [ ] You **don't** try to edit the React app site in Experience Builder (not supported)
+
+## Agentforce Conversation Client (only if embedding ACC)
+
+- [ ] An **Employee Agent** with topics + actions exists in the org
+- [ ] Setup → Einstein → Agentforce Studio → **Agentforce preference** is enabled
+- [ ] Setup → My Domain → **"Require first-party use of Salesforce cookies"** is **unchecked**
+- [ ] Setup → Session Settings → **Trusted Domains for Inline Frames** includes the host origin (prod, preview, and `http://localhost:<port>` for dev), iFrame type **Lightning Out**
+- [ ] `npm install @salesforce/agentforce-conversation-client` completed
+- [ ] Mount lifecycle uses `useRef` + `useEffect` and unmount cleanup
+
+## Data SDK & GraphQL
+
+- [ ] All Salesforce calls go through `@salesforce/sdk-data` (`createDataSDK`, `gql`)
+- [ ] **No raw `fetch()` or `axios`** to Salesforce endpoints
+- [ ] `schema.graphql` generated from a connected org (`npm run graphql:schema`)
+- [ ] `src/api/graphql-operations-types.ts` regenerated after every `.graphql` edit (`npm run graphql:codegen`)
+- [ ] Optional chaining used: `sdk.graphql?.()`, `sdk.fetch?.()`
+- [ ] Field reads use `{ value }` shape: `record.Name.value`
+- [ ] Connection reads use `edges/node` pattern: `result.uiapi.query.X.edges?.map(e => e?.node)`
+- [ ] Error strategy chosen per call site: Strict / Tolerant / Permissive
+- [ ] 401 / 403 callbacks wired (`on401`, `on403`) where auth flows are user-initiated
+
+## Styling
+
+- [ ] One styling system per component (no SLDS + Tailwind inside the same JSX)
+- [ ] SLDS-styled components either use the official blueprint classes or `@salesforce/design-system-react`, not both
+- [ ] Focus ring color uses Salesforce blue `#0176d3` if you want native-feeling focus
+- [ ] Dark mode handled via `.dark` token overrides in `global.css` (when using Tailwind/shadcn)
+
+## Build & Deploy
+
+- [ ] `npm run lint` passes
+- [ ] `npm run build` passes (this is the artifact that ships)
+- [ ] `dist/` size is sane and < 2,500 files (UIBundle ceiling)
+- [ ] Deploy via `sf project deploy start --source-dir force-app/main/default/uiBundles/<appName>` (or MCP equivalent)
+- [ ] Smoke-test: open the app in App Launcher (internal) or Digital Experiences (external)
+- [ ] Smoke-test: hard-refresh on a deep route — should not 404
+
+## Anti-Patterns (block before they ship)
+
+- [ ] **No** Lightning base components (`lightning-card`, `lightning-button`) — not supported in React UI bundles
+- [ ] **No** `@wire` decorators
+- [ ] **No** `@salesforce/*` imports other than `sdk-data`, ACC, or `@salesforce/ui-bundle`
+- [ ] **No** raw `fetch()` to `/services/data/...`
+- [ ] **No** debug code (`console.log` of SDK objects, response dumps) in committed recipes

--- a/skills/sf-multiframework/references/authoring-surface.md
+++ b/skills/sf-multiframework/references/authoring-surface.md
@@ -1,0 +1,109 @@
+# Authoring Surfaces
+
+Salesforce markets **Agentforce Vibes** as *an* authoring path for Multi-Framework. It is one option among several. This skill is designed to work in any of:
+
+- **Any MCP-capable AI coding assistant** (IDE-integrated or CLI-based)
+- **Agentforce Vibes** (VS Code extension)
+- **Plain `sf` CLI + editor** (no AI assistant at all)
+
+The platform pieces — CLI, plugin, project template, Data SDK, ACC — are the same regardless of authoring surface. This file captures what differs.
+
+## Why this matters
+
+If you work with an MCP-capable assistant, you don't need the Vibes extension to build UI bundles. Install the CLI + plugin and the rest is standard npm / Vite work with this skill layered in for Salesforce-specific guidance.
+
+If you work in Vibes, it brings natural-language prompts that scaffold Data SDK GraphQL code (operations, types, error handling) and ACC integration. Use those prompts as a starting point; the rules in this skill still apply to the output.
+
+## Surface comparison
+
+| Capability | Generic MCP-capable assistant | Agentforce Vibes |
+|---|---|---|
+| Scaffold project with `sf template generate ui-bundle` | ✅ plain CLI | ✅ CLI; Vibes can also prompt |
+| Generate GraphQL query + types + component | ✅ via this skill | ✅ built-in slash commands |
+| Generate ACC widget mount | ✅ via [acc-integration.md](acc-integration.md) | ✅ built-in prompt |
+| MCP servers for org context | ✅ install any MCP server | ✅ "Metadata Experts" + "API Context" MCP servers shipped |
+| Operates on existing code | ✅ | ✅ |
+| Works offline (no live org) | ✅ | ⚠️ some prompts require a connected org |
+| LLM provider | Your choice | Salesforce's Einstein models |
+
+Neither surface is "correct" — pick based on team preference and which LLM you want behind the generation.
+
+## CLI + plugin requirements (all surfaces)
+
+```bash
+# Node + sf CLI
+node --version   # ≥ 22
+sf --version     # latest
+
+# UI bundle plugin
+sf plugins install @salesforce/plugin-ui-bundle-dev
+
+# Verify
+sf template generate ui-bundle --help
+```
+
+If `sf template generate ui-bundle` is not recognized, the plugin didn't install. Re-run install; if it still fails, `sf plugins uninstall @salesforce/plugin-ui-bundle-dev && sf plugins install @salesforce/plugin-ui-bundle-dev`.
+
+## Vibes-specific: enabling MCP servers in-org
+
+If (and only if) you use Vibes:
+
+1. Setup → MCP Servers → enable **Metadata Experts** and **API Context**
+2. In VS Code, open the Agentforce Vibes panel and confirm both connect
+3. The MCP servers use your authenticated `sf` CLI session
+
+Non-Vibes assistants don't need this — their MCP wiring is client-side (in whatever config file the assistant uses).
+
+## Working without Vibes
+
+A reasonable non-Vibes workflow:
+
+```bash
+# 1. Scaffold
+cd my-dx-project
+sf template generate ui-bundle --name myApp --template reactinternalapp
+cd force-app/main/default/uiBundles/myApp
+npm install
+
+# 2. Generate the schema once against a connected org
+npm run graphql:schema
+
+# 3. Ask the assistant to
+#    "add a recipe that lists the first 10 Accounts with aliased multi-object query"
+#    — the assistant writes the .graphql file, runs codegen, and emits the component.
+#    Apply this skill's rules (UI API `{ value }`, inline `gql` for recipes, etc.)
+
+# 4. Build + deploy
+npm run build
+cd ../../../../..
+sf project deploy start --source-dir force-app/main/default/uiBundles/myApp
+```
+
+## Prompt patterns that work in any assistant
+
+When telling an assistant to generate a recipe, include:
+
+1. **The target object + fields** (e.g. "Contact: Name, Title, Phone")
+2. **The operation** (query first 10 / query by ID / mutation create)
+3. **The error strategy** (strict / tolerant / permissive — see [error-handling.md](error-handling.md))
+4. **The styling system** (SLDS / DSR / shadcn)
+5. **Whether `gql` is inline or external `.graphql`** (recipes: inline; complex reusable: external + codegen)
+
+Example:
+
+> Build a recipe `src/recipes/read-data/SingleContact.tsx` that queries the first Contact by ID via inline `gql`, uses strict error handling, and renders an SLDS card. Mock the SDK in a sibling test file with `vitest-axe` assertions.
+
+Any assistant that can read this skill's references will produce the right shape.
+
+## When to switch surfaces
+
+| You're in… | Consider switching when… |
+|---|---|
+| Vibes | You want a different LLM; you need MCP servers outside Vibes' bundled set; you want terminal-native workflows |
+| Generic assistant | You want the in-org MCP context for metadata / API introspection; the team standardizes on Vibes |
+
+## What *not* to do
+
+- ❌ Don't mix generated files across assistants without review — each has quirks (import ordering, JSX syntax, test patterns). Apply [recipe-conventions.md](recipe-conventions.md) as the arbiter.
+- ❌ Don't rely on any assistant's memory of Multi-Framework — the feature is Beta and changes frequently. Point the assistant at this skill + the official docs ([official-sources.md](official-sources.md)).
+- ❌ Don't install Vibes on a project where the team uses a different assistant unless there's a reason — the surfaces can generate conflicting patterns (e.g. external `.graphql` vs inline `gql`).

--- a/skills/sf-multiframework/references/ci-deploy.md
+++ b/skills/sf-multiframework/references/ci-deploy.md
@@ -1,0 +1,279 @@
+# CI/CD and Deploy
+
+Multi-Framework has deploy rules that don't exist for plain LWC. Get these wrong and either the metadata deploy fails or the app deploys but doesn't run.
+
+## The non-negotiable rules
+
+| Rule | Why |
+|---|---|
+| **Build first, then deploy** | `sf project deploy start` ships whatever is in `outputDir` (`dist/`). No build = empty deploy = blank app. |
+| **One UI bundle per metadata push (safe default)** | Multi-bundle deploys can collide; scope to one bundle at a time unless you've validated the combo. |
+| **2,500-file ceiling per `UIBundle`** | `dist/` must stay under this. Source maps and vendored binaries bust the limit fast. |
+| **`tsc -b && vite build` must pass** | The build script is `tsc -b && vite build` — TypeScript errors block the build, they're not warnings. |
+| **`npm run lint` must pass** | ESLint flat config; violations block CI. |
+| **Deploy from project root** | `sf project deploy start` resolves `force-app` from the root, not the bundle dir. |
+
+## Standard deploy sequence
+
+```bash
+# 1. Build (inside the bundle)
+cd force-app/main/default/uiBundles/myApp
+npm install
+npm run graphql:schema   # first time / when schema drifted
+npm run graphql:codegen
+npm run build            # → dist/
+
+# 2. Deploy (from project root)
+cd -
+sf project deploy start \
+  --source-dir force-app/main/default/uiBundles/myApp \
+  --target-org TARGET_ORG \
+  --json
+```
+
+If the team uses the **Salesforce DX MCP server** (`mcp_Salesforce_DX_deploy_metadata`), prefer it — same result, structured output.
+
+## The `dist/` 2,500-file budget
+
+You will hit this faster than you think. Common offenders:
+
+| Offender | Fix |
+|---|---|
+| Per-file source maps (one per chunk) | `build.sourcemap: false` in `vite.config.ts` for prod builds |
+| SLDS sprite maps exploded per icon | Keep `@salesforce-ux/design-system` sprite SVGs; don't copy icons into `public/` |
+| Vendored Lucide icons as individual files | `lucide-react` is fine as a dependency; don't copy its `dist/` into your `public/` |
+| Duplicate font files (ttf/woff/woff2/eot) | Ship woff2 only |
+| `node_modules/.cache` leaking into `dist/` | Add `.cache/` to `.gitignore` and `.forceignore` |
+
+Audit before deploy:
+
+```bash
+find dist -type f | wc -l
+find dist -type f -name "*.map" | wc -l    # source maps
+du -sh dist/assets/* | sort -h              # biggest assets
+```
+
+### `.forceignore` for React bundles
+
+Deploys from `force-app/` pick up *everything* by default. Add to `.forceignore`:
+
+```
+# React build artifacts that shouldn't deploy alongside their source
+**/node_modules/
+**/coverage/
+**/playwright-report/
+**/test-results/
+
+# package.xml is SFDX legacy; the CLI generates its own
+package.xml
+
+# LWC boilerplate that lands in new DX projects
+**/jsconfig.json
+**/.eslintrc.json
+**/__tests__/**
+
+# macOS
+.DS_Store
+```
+
+`dist/` itself *must* deploy — it's the bundle payload. Only exclude build caches and test output.
+
+## Scratch org definition for Multi-Framework
+
+The scratch definition needs **`UIBundleSettings.webAppOptIn: true`** and `en_US`:
+
+```json
+{
+  "orgName": "Multi-Framework Dev Org",
+  "edition": "developer",
+  "language": "en_US",
+  "features": ["EnableSetPasswordInApi"],
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "UIBundleSettings": {
+      "webAppOptIn": true
+    },
+    "mobileSettings": {
+      "enableS1EncryptedStoragePref2": false
+    }
+  }
+}
+```
+
+Without `webAppOptIn`, the scratch org won't have Multi-Framework enabled and metadata deploys fail with feature-not-enabled errors.
+
+### `sfdx-project.json`
+
+```json
+{
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true,
+      "package": "MyReactApp",
+      "versionName": "v1",
+      "versionNumber": "1.0.0.NEXT"
+    }
+  ],
+  "name": "my-react-app",
+  "namespace": "",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "66.0"
+}
+```
+
+`sourceApiVersion` must match the `apiVersion` in `ui-bundle.json`. Mismatches cause "metadata type not found" errors.
+
+## CI/CD reference workflow (GitHub Actions)
+
+The trailheadapps reference repo uses Volta for node pinning, separate caches for root and bundle `node_modules`, coverage upload, and Playwright browser caching. Adapt to any CI system.
+
+```yaml
+name: CI
+on:
+  workflow_dispatch:
+  push: { branches: [main], paths-ignore: [README.md, sfdx-project.json] }
+  pull_request: { branches: [main] }
+
+jobs:
+  react-app:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: force-app/main/default/uiBundles/myApp
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: volta-cli/action@v4
+
+      - name: Cache React app node_modules
+        id: cache-react-npm
+        uses: actions/cache@v4
+        with:
+          path: force-app/main/default/uiBundles/myApp/node_modules
+          key: react-npm-${{ hashFiles('force-app/main/default/uiBundles/myApp/package-lock.json') }}
+
+      - name: Install
+        if: steps.cache-react-npm.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests + coverage
+        run: npm run test -- --run --coverage
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./force-app/main/default/uiBundles/myApp/coverage/lcov.info
+
+      - name: Build
+        run: npm run build
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: force-app/main/default/uiBundles/myApp/playwright-report
+
+  deploy-preview:
+    needs: react-app
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: volta-cli/action@v4
+      - run: npm ci --prefix force-app/main/default/uiBundles/myApp
+      - run: npm run build --prefix force-app/main/default/uiBundles/myApp
+      - name: Install sf CLI
+        run: npm install -g @salesforce/cli
+      - name: Install UI bundle plugin
+        run: sf plugins install @salesforce/plugin-ui-bundle-dev
+      - name: Authenticate
+        run: echo "${{ secrets.SFDX_AUTH_URL }}" | sf org login sfdx-url --set-default
+      - name: Deploy to sandbox
+        run: sf project deploy start --source-dir force-app/main/default/uiBundles/myApp --json
+```
+
+### What to cache
+
+| Target | Why |
+|---|---|
+| Root `node_modules/` | SFDX / Prettier / Husky stuff |
+| Bundle `node_modules/` | React app deps — the big one; cache saves 30-60s |
+| `~/.cache/ms-playwright` | Browser downloads are ~300 MB; always cache |
+| `.vite/` (optional) | Vite build cache across runs |
+
+## PR preview deploys
+
+For PR preview orgs, use scratch orgs with `--duration-days 1`:
+
+```bash
+sf org create scratch \
+  --definition-file config/project-scratch-def.json \
+  --alias pr-${{ github.event.number }} \
+  --duration-days 1 \
+  --set-default
+
+npm run build --prefix force-app/main/default/uiBundles/myApp
+sf project deploy start --source-dir force-app/main/default/uiBundles/myApp
+sf org assign permset --name MyAppUser
+sf org open
+```
+
+## Pre-commit hook
+
+The reference repo uses Husky + lint-staged:
+
+```json
+// package.json (root)
+{
+  "husky": { "hooks": { "pre-commit": "lint-staged" } },
+  "lint-staged": {
+    "force-app/main/default/uiBundles/myApp/**/*.{ts,tsx}": [
+      "npm run lint --prefix force-app/main/default/uiBundles/myApp --",
+      "prettier --write"
+    ]
+  }
+}
+```
+
+## Deploy failure diagnostics
+
+| Error | Cause | Fix |
+|---|---|---|
+| `UIBundle: The file count ... exceeds the maximum` | >2,500 files in `dist/` | Prune source maps, sprite copies, fonts |
+| `Component type 'UIBundle' not found` | API version mismatch | Align `sourceApiVersion` (sfdx-project.json) and `apiVersion` (ui-bundle.json) and org version |
+| `Metadata API response: Required field 'masterLabel' missing` | `.uibundle-meta.xml` missing fields | Ensure `<masterLabel>`, `<isActive>`, `<version>` |
+| `Insufficient access rights on cross-reference id` | Running user lacks permset to deploy UIBundle | Grant the deploy user `ModifyAllData` or the right system permission |
+| Deploy succeeds but app never appears | Wrong `target` in `.uibundle-meta.xml`; or Experience site missing `appContainer: true` | Confirm `AppLauncher` vs `Experience` and `digitalExperiences/.../content.json` |
+| `sf template generate ui-bundle` not recognized | Plugin missing | `sf plugins install @salesforce/plugin-ui-bundle-dev` |
+| `UIBundleSettings` feature not enabled on scratch org | `webAppOptIn` not set | Add `"UIBundleSettings": { "webAppOptIn": true }` to scratch def |
+
+## Multi-bundle repos
+
+If you deploy more than one UI bundle from the same project:
+
+- Deploy them in separate `sf project deploy start` calls
+- Build each one in its own bundle directory
+- Keep bundle names unique across the org (they're first-class metadata records)
+- Share code via a **private npm package** or workspace, not by importing across `uiBundles/`
+
+Cross-bundle imports break in the built output even if they compile in dev — the plugin scopes each bundle.

--- a/skills/sf-multiframework/references/ci-deploy.md
+++ b/skills/sf-multiframework/references/ci-deploy.md
@@ -9,7 +9,7 @@ Multi-Framework has deploy rules that don't exist for plain LWC. Get these wrong
 | **Build first, then deploy** | `sf project deploy start` ships whatever is in `outputDir` (`dist/`). No build = empty deploy = blank app. |
 | **One UI bundle per metadata push (safe default)** | Multi-bundle deploys can collide; scope to one bundle at a time unless you've validated the combo. |
 | **2,500-file ceiling per `UIBundle`** | `dist/` must stay under this. Source maps and vendored binaries bust the limit fast. |
-| **`tsc -b && vite build` must pass** | The build script is `tsc -b && vite build` — TypeScript errors block the build, they're not warnings. |
+| **`tsc --noEmit && vite build` must pass** | TypeScript errors block the build, and `--noEmit` avoids stray root artifacts being deployed as bundle members. |
 | **`npm run lint` must pass** | ESLint flat config; violations block CI. |
 | **Deploy from project root** | `sf project deploy start` resolves `force-app` from the root, not the bundle dir. |
 
@@ -63,6 +63,9 @@ Deploys from `force-app/` pick up *everything* by default. Add to `.forceignore`
 **/coverage/
 **/playwright-report/
 **/test-results/
+**/*.tsbuildinfo
+**/vite.config.js
+**/vite.config.d.ts
 
 # package.xml is SFDX legacy; the CLI generates its own
 package.xml
@@ -124,7 +127,7 @@ Without `webAppOptIn`, the scratch org won't have Multi-Framework enabled and me
 }
 ```
 
-`sourceApiVersion` must match the `apiVersion` in `ui-bundle.json`. Mismatches cause "metadata type not found" errors.
+`sourceApiVersion` should match the target org API version. Current UI bundle validators can reject `apiVersion` inside `ui-bundle.json`, so keep the API version in `sfdx-project.json` and deployment tooling rather than the runtime config file.
 
 ## CI/CD reference workflow (GitHub Actions)
 
@@ -260,12 +263,16 @@ The reference repo uses Husky + lint-staged:
 | Error | Cause | Fix |
 |---|---|---|
 | `UIBundle: The file count ... exceeds the maximum` | >2,500 files in `dist/` | Prune source maps, sprite copies, fonts |
-| `Component type 'UIBundle' not found` | API version mismatch | Align `sourceApiVersion` (sfdx-project.json) and `apiVersion` (ui-bundle.json) and org version |
+| `Component type 'UIBundle' not found` | API version mismatch or Multi-Framework not enabled | Align `sourceApiVersion` with the org version and confirm Multi-Framework is enabled |
+| `ui-bundle.json contains unknown property: 'apiVersion'` | Runtime config schema only allows `outputDir`, `routing`, `headers` | Remove `apiVersion` from `ui-bundle.json` |
+| `apiVersion invalid at this location in type UIBundle` | `.uibundle-meta.xml` contains unsupported `<apiVersion>` | Remove `<apiVersion>` from the UIBundle XML |
+| `isEnabled invalid at this location in type UIBundle` | Wrong field name in `.uibundle-meta.xml` | Use `<isActive>true</isActive>` and include `<version>` |
 | `Metadata API response: Required field 'masterLabel' missing` | `.uibundle-meta.xml` missing fields | Ensure `<masterLabel>`, `<isActive>`, `<version>` |
 | `Insufficient access rights on cross-reference id` | Running user lacks permset to deploy UIBundle | Grant the deploy user `ModifyAllData` or the right system permission |
 | Deploy succeeds but app never appears | Wrong `target` in `.uibundle-meta.xml`; or Experience site missing `appContainer: true` | Confirm `AppLauncher` vs `Experience` and `digitalExperiences/.../content.json` |
 | `sf template generate ui-bundle` not recognized | Plugin missing | `sf plugins install @salesforce/plugin-ui-bundle-dev` |
 | `UIBundleSettings` feature not enabled on scratch org | `webAppOptIn` not set | Add `"UIBundleSettings": { "webAppOptIn": true }` to scratch def |
+| Second deploy reports conflicts on the bundle just created | Source tracking sees the org-created bundle as remote changes | If the remote state is your previous deploy, rerun the targeted bundle deploy with `--ignore-conflicts` |
 
 ## Multi-bundle repos
 

--- a/skills/sf-multiframework/references/cli-guide.md
+++ b/skills/sf-multiframework/references/cli-guide.md
@@ -1,0 +1,135 @@
+# CLI Guide
+
+> Prefer **Salesforce DX MCP** for deployments when available (`mcp_Salesforce_DX_deploy_metadata`, `mcp_Salesforce_DX_get_username`). The CLI commands below are the documented fallback and what most people run locally.
+
+## Required plugins
+
+```bash
+sf plugins install @salesforce/plugin-ui-bundle-dev
+```
+
+This plugin provides:
+
+- `sf template generate ui-bundle` — scaffolding
+- Runtime support used by `npm run dev` for the Vite plugin
+
+## Scaffolding
+
+### Add a UI bundle to an existing project
+
+```bash
+sf template generate ui-bundle \
+  --name myApp \
+  --template reactinternalapp     # or reactexternalapp
+```
+
+The `--name` becomes the bundle directory name and the metadata API name. Stick with a developer-name-friendly identifier (no spaces, no leading digits).
+
+### Generate a new DX project + external app
+
+```bash
+sf template generate project --template reactexternalapp
+```
+
+Use this when starting from a clean directory.
+
+## Local development
+
+```bash
+cd force-app/main/default/uiBundles/myApp
+npm install
+npm run graphql:schema     # Introspects the connected org → schema.graphql
+npm run graphql:codegen    # Reads codegen.yml → src/api/graphql-operations-types.ts
+npm run dev                # Vite dev server (default http://localhost:5173)
+```
+
+Notes:
+
+- `graphql:schema` requires an **already-authorized org**. Make sure `sf org list` shows your target.
+- The Vite plugin (`@salesforce/vite-plugin-ui-bundle`) proxies Salesforce API calls during dev so the SDK works against the real org.
+- Add `http://localhost:<port>` to **Trusted Domains for Inline Frames** if you're testing ACC locally.
+
+## Build
+
+```bash
+npm run build
+```
+
+Typically `tsc -b && vite build`. Output lands in the directory referenced by `ui-bundle.json` `outputDir` (Vite default `dist/`).
+
+`npm run lint` and `npm run build` should both pass before you deploy.
+
+## Deploy (CLI)
+
+```bash
+# From the project root
+sf project deploy start \
+  --source-dir force-app/main/default/uiBundles/myApp \
+  --target-org TARGET_ORG
+```
+
+For external apps, deploy the companion folders **in the same call**:
+
+```bash
+sf project deploy start \
+  --source-dir force-app/main/default/uiBundles/myApp \
+  --source-dir force-app/main/default/digitalExperiences \
+  --source-dir force-app/main/default/digitalExperienceConfigs \
+  --source-dir force-app/main/default/networks \
+  --source-dir force-app/main/default/sites \
+  --target-org TARGET_ORG
+```
+
+> **Only one UI bundle deploys per metadata push** is the safe pattern. If you have multiple bundles in your project, deploy them in separate `sf project deploy start` calls.
+
+## Deploy (MCP — preferred)
+
+```js
+// 1. Get the org alias
+mcp_Salesforce_DX_get_username({ defaultTargetOrg: true })
+
+// 2. Deploy
+mcp_Salesforce_DX_deploy_metadata({
+  usernameOrAlias: "myorg",
+  sourceDir: ["force-app/main/default/uiBundles/myApp"]
+})
+```
+
+For external apps, include all four supporting folders in `sourceDir`.
+
+## Open the org
+
+```bash
+sf org open
+# Or via MCP:
+mcp_Salesforce_DX_open_org({ usernameOrAlias: "myorg" })
+```
+
+## Sample data import
+
+Most templates include a `data/` folder with a tree plan for sample records:
+
+```bash
+sf data import tree --plan ./data/data-plan.json --target-org TARGET_ORG
+```
+
+## Common CLI failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `sf template generate ui-bundle` not recognized | Plugin missing | `sf plugins install @salesforce/plugin-ui-bundle-dev` |
+| `npm run graphql:schema` fails with auth error | No authorized org in this shell | `sf org login web -a alias` and re-run |
+| Deploy fails with file-count error | UIBundle ≥ 2,500 files | Disable source maps, prune `dist/` |
+| Deploy succeeds but app missing from App Launcher | `<isActive>` is `false` or `<target>` mismatch | Set `isActive` true; confirm target |
+| External app deploys but site is empty | Forgot to deploy `digitalExperiences`, `networks`, or `sites` | Re-deploy with all four folders |
+| Vite dev server data calls 401 | Org authorization expired | `sf org login web -a alias` |
+| Build OK locally but deploy fails | `outputDir` in `ui-bundle.json` doesn't match where the build emits | Align `outputDir` with `vite.config.ts` `build.outDir` |
+
+## Useful org-side commands
+
+```bash
+sf org assign permset -n recipes                     # Assign starter PSet
+sf org list                                          # See all authorized orgs
+sf org display --target-org alias --verbose          # Confirm API version, instance URL
+sf org open --target-org alias                       # Open the org in browser
+```

--- a/skills/sf-multiframework/references/cli-guide.md
+++ b/skills/sf-multiframework/references/cli-guide.md
@@ -55,7 +55,7 @@ Notes:
 npm run build
 ```
 
-Typically `tsc -b && vite build`. Output lands in the directory referenced by `ui-bundle.json` `outputDir` (Vite default `dist/`).
+Typically `tsc --noEmit && vite build`. Output lands in the directory referenced by `ui-bundle.json` `outputDir` (Vite default `dist/`). Avoid `tsc -b` unless project references are intentionally configured, because it can emit TypeScript build artifacts into the deployable bundle root.
 
 `npm run lint` and `npm run build` should both pass before you deploy.
 

--- a/skills/sf-multiframework/references/data-sdk.md
+++ b/skills/sf-multiframework/references/data-sdk.md
@@ -1,0 +1,247 @@
+# Data SDK (`@salesforce/sdk-data`)
+
+The Data SDK is the **only** sanctioned way to call Salesforce APIs from a React UI bundle. It abstracts authentication, CSRF token management, and base-path resolution across surfaces (Lightning Experience, Experience Cloud sites, the local Vite dev server).
+
+> Never call `fetch()` or `axios` directly to a Salesforce endpoint from a React UI bundle.
+
+## Why use it
+
+| Feature | Benefit |
+|---|---|
+| **Surface abstraction** | Same code works in App Launcher, Experience Cloud, and `localhost` dev |
+| **Capability detection** | The SDK detects the runtime and picks the right transport |
+| **TypeScript-first** | Full IntelliSense, compile-time safety, Promise-based error flow |
+| **Auth + CSRF** | Handled internally — you don't manage tokens |
+
+## Public API surface
+
+| Export | Type | Purpose |
+|---|---|---|
+| `createDataSDK` | async function | Factory that returns a `DataSDK` instance |
+| `gql` | template tag | Identity tag for inline GraphQL queries; enables editor highlighting and codegen detection |
+| `DataSDK` | interface | The SDK surface (`graphql`, `fetch`) |
+| `SDKOptions` | interface | Optional surface override |
+| `NodeOfConnection<T>` | utility type | Extracts node type from `{ edges { node ... } }` connection responses |
+
+## `createDataSDK(options?)`
+
+```ts
+import { createDataSDK } from "@salesforce/sdk-data";
+
+const sdk = await createDataSDK({
+  surface: "webapp",
+  webapp: {
+    basePath: "/my-experience-site",
+    on401: () => signInAgain(),
+    on403: () => showPermissionsHelp()
+  }
+});
+```
+
+Options shape:
+
+```ts
+type DataSDKOptions = {
+  surface?: string;                          // for explicit surface detection
+  webapp?: {
+    basePath?: string;                       // URL prefix for SF API calls
+    on401?: () => Promise<unknown> | void;   // optional 401 hook
+    on403?: () => Promise<unknown> | void;   // optional 403 hook
+  };
+};
+```
+
+The 401/403 callbacks are essential for **Experience Cloud** apps where users may need to sign in again or be guided to permission setup.
+
+## `sdk.graphql?.()`
+
+```ts
+const res = await sdk.graphql?.(QUERY, variables);
+```
+
+Use **optional chaining** (`?.()`) — `graphql` is not guaranteed in every surface.
+
+GraphQL is the **preferred** path for record reads and writes.
+
+### Defining queries
+
+#### Inline with `gql` (simple)
+
+```ts
+import { createDataSDK, gql } from "@salesforce/sdk-data";
+
+const QUERY = gql`
+  query SingleAccount {
+    uiapi {
+      query {
+        Account(first: 1) {
+          edges {
+            node {
+              Id
+              Name { value }
+              Industry { value }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+```
+
+The `gql` tag is an identity template literal. It triggers:
+
+- editor syntax highlighting (with Agentforce Vibes / GraphQL extensions)
+- codegen detection
+- runtime type-tagged operation registration
+
+#### External `.graphql` file (complex / shared)
+
+```
+src/api/utils/query/singleAccountQuery.graphql
+src/api/graphql-operations-types.ts          # generated
+```
+
+```ts
+import QUERY from "./query/singleAccountQuery.graphql?raw";
+import type { SingleAccountQuery, SingleAccountQueryVariables }
+  from "../graphql-operations-types";
+```
+
+Use external files when the query has variables, fragments, or is shared across files. See [graphql-workflow.md](graphql-workflow.md) for the codegen pipeline.
+
+### UI API response shape — every field is wrapped in `{ value }`
+
+```ts
+const data = await sdk.graphql?.(QUERY);
+const edges = data?.uiapi.query.Account.edges;
+
+edges?.forEach(edge => {
+  const acct = edge?.node;
+  console.log(acct?.Name.value);       // "Acme Corp"
+  console.log(acct?.Industry.value);   // "Technology"
+});
+```
+
+This is **Salesforce-specific**. Standard GraphQL doesn't wrap fields. Comment this in code aimed at React-first developers.
+
+### `NodeOfConnection<T>`
+
+```ts
+import type { NodeOfConnection } from "@salesforce/sdk-data";
+import type { ListAccountsQuery } from "../graphql-operations-types";
+
+type AccountNode = NodeOfConnection<
+  NonNullable<ListAccountsQuery["uiapi"]>["query"]["Account"]
+>;
+
+function renderRow(node: AccountNode) {
+  return <tr><td>{node.Name.value}</td></tr>;
+}
+```
+
+Use when:
+- the response uses the `edges/node` connection shape
+- you want a clean strongly-typed node alias for transforms / props / list rendering
+
+Skip when your generated types are already flat / non-connection.
+
+## `sdk.fetch?.()`
+
+```ts
+const res = await sdk.fetch?.(
+  "/services/data/v66.0/ui-api/records/001xx0000000000",
+  { method: "GET" }
+);
+```
+
+Use for endpoints **not** covered by GraphQL. The wrapper handles:
+
+- **CSRF token management**
+- **Base path resolution** (so the same code works in dev, sandbox, Experience site)
+- **401 / 403 callback hooks** registered in `createDataSDK` options
+
+### Allow-listed endpoints
+
+`sdk.fetch?.()` is supported for these endpoint shapes:
+
+```
+/services/apexrest/...
+/services/data/v{version}/ui-api/records
+/services/data/v{version}/ui-api/search-info
+/services/data/v{version}/ui-api/layout
+/services/data/v{version}/ui-api/session/csrf
+/services/data/v{version}/connect/file/upload/config
+/services/data/v{version}/connect/proxy/ui-telemetry
+/services/data/v{version}/chatter/users/me
+/services/data/v{version}/chatter/users/{userId}
+/sfsites/c/_nc_external/system/security/session/SessionTimeServlet
+/secur/logout.jsp
+```
+
+Anything outside this list is not guaranteed to work and should go through Apex REST instead.
+
+### When to use `fetch` over GraphQL
+
+- Apex REST endpoints exposing custom business logic GraphQL can't express.
+- UI API REST endpoints not exposed via GraphQL (search-info, layout, chatter users, session/csrf).
+- File upload bootstrap (`connect/file/upload/config`).
+- GraphQL with a GET request (small queries with URL constraints, or when you specifically need a CSRF round-trip).
+
+## Order of preference for data access
+
+1. **GraphQL queries / mutations** via `sdk.graphql?.()`
+2. **UI API REST / Apex REST** via `sdk.fetch?.()`
+3. **GraphQL with `sdk.fetch?.()` GET** for the niche cases above
+4. **Apex REST** when GraphQL can't do it
+
+## Anti-patterns
+
+```ts
+// ❌ NEVER — bypasses auth, CSRF, base path
+const res = await fetch("/services/data/v66.0/ui-api/records/001...");
+
+// ❌ NEVER — same problem
+const res = await axios.get("/services/data/...");
+
+// ❌ Forgetting optional chaining — crashes in surfaces that don't expose graphql
+const res = await sdk.graphql(QUERY);
+
+// ✅ Correct
+const res = await sdk.graphql?.(QUERY, variables);
+```
+
+## Reference wrapper (`graphqlClient.ts`)
+
+The `multiframework-recipes` repo uses a thin wrapper:
+
+```ts
+// src/api/graphqlClient.ts
+import { createDataSDK } from "@salesforce/sdk-data";
+export { gql } from "@salesforce/sdk-data";
+
+export async function executeGraphQL<TData, TVars = Record<string, unknown>>({
+  query,
+  variables
+}: {
+  query: string;
+  variables?: TVars;
+}): Promise<TData> {
+  const sdk = await createDataSDK();
+  const response = await sdk.graphql?.(query, variables);
+
+  if (!response) throw new Error("GraphQL surface unavailable");
+  if (response.errors?.length && !response.data) {
+    throw new Error(response.errors.map(e => e.message).join("; "));
+  }
+  return response.data as TData;
+}
+```
+
+This is a **Strict** error strategy. See [error-handling.md](error-handling.md) for Tolerant and Permissive variants.
+
+## See also
+
+- [graphql-workflow.md](graphql-workflow.md) — codegen and operation generation
+- [error-handling.md](error-handling.md) — Strict / Tolerant / Permissive
+- [Multi-Framework Recipes](https://github.com/trailheadapps/multiframework-recipes) — reference implementations

--- a/skills/sf-multiframework/references/error-handling.md
+++ b/skills/sf-multiframework/references/error-handling.md
@@ -1,0 +1,232 @@
+# Error Handling
+
+GraphQL responses can carry **both `data` and `errors`** in the same payload — partial success is a real outcome. `sdk.fetch?.()` calls add transport errors and HTTP-level errors on top. Pick a strategy per call site based on what "good enough" means for that operation.
+
+## Three GraphQL error strategies
+
+### 1. Strict — fail on any error
+
+> Use when: data integrity matters; partial data would mislead the user.
+
+```ts
+async function strictExecute<T>(query: string, variables?: object): Promise<T> {
+  const sdk = await createDataSDK();
+  const response = await sdk.graphql?.(query, variables);
+  if (!response) throw new Error("GraphQL surface unavailable");
+  if (response.errors?.length) {
+    throw new Error(response.errors.map(e => e.message).join("; "));
+  }
+  return response.data as T;
+}
+```
+
+Good fit: financial summaries, compliance lookups, anything where a partial result is worse than no result.
+
+### 2. Tolerant — log errors, use partial data
+
+> Use when: optional fields can be missing; the UI degrades gracefully.
+
+```ts
+async function tolerantExecute<T>(query: string, variables?: object): Promise<T> {
+  const sdk = await createDataSDK();
+  const response = await sdk.graphql?.(query, variables);
+  if (!response?.data) {
+    throw new Error("No data returned");
+  }
+  if (response.errors?.length) {
+    console.warn("GraphQL partial errors:", response.errors);
+  }
+  return response.data as T;
+}
+```
+
+Good fit: list views with optional fields (e.g. `Photo`, `Industry`) where missing values render as empty cells.
+
+### 3. Permissive — fail only when nothing usable came back
+
+> Use when: mutations succeed but can't read back every requested field; the operation itself is what matters.
+
+```ts
+async function permissiveExecute<T>(query: string, variables?: object): Promise<T> {
+  const sdk = await createDataSDK();
+  const response = await sdk.graphql?.(query, variables);
+  if (!response) throw new Error("GraphQL surface unavailable");
+  if (!response.data && response.errors?.length) {
+    throw new Error(response.errors.map(e => e.message).join("; "));
+  }
+  return response.data as T;
+}
+```
+
+Good fit: `<Object>Update` mutations that return a `Record` containing fields the user lacks read access to.
+
+## Picking a strategy
+
+```
+Is this a mutation that may have field-read errors?
+  ├─ yes → Permissive
+  └─ no
+      Is the data critical (financial, legal, privileged)?
+      ├─ yes → Strict
+      └─ no  → Tolerant
+```
+
+## `sdk.fetch?.()` errors
+
+`fetch` errors come in two layers:
+
+### Transport errors
+
+Network failures, aborted requests, CSRF mismatches. The `fetch` promise rejects.
+
+```ts
+try {
+  const res = await sdk.fetch?.("/services/data/v66.0/ui-api/records/...", {
+    method: "GET"
+  });
+  if (!res) throw new Error("fetch surface unavailable");
+  if (!res.ok) {
+    // HTTP error path — see below
+    throw new HttpError(res.status, await res.text());
+  }
+  return await res.json();
+} catch (e) {
+  // Transport error path
+  console.error("Transport failure", e);
+  throw e;
+}
+```
+
+### HTTP errors
+
+Non-2XX responses. Distinguish auth-sensitive flows (`401`, `403`) from server errors.
+
+```ts
+if (res.status === 401) {
+  await onSignInRefresh();
+  return retryOnce();
+}
+if (res.status === 403) {
+  showPermissionsHelp();
+  throw new Error("Insufficient permissions for this action");
+}
+if (res.status >= 500) {
+  throw new Error(`Server error ${res.status}`);
+}
+```
+
+For auth-sensitive flows, prefer wiring `on401` / `on403` callbacks at the SDK level so the same behavior runs for every call:
+
+```ts
+const sdk = await createDataSDK({
+  webapp: {
+    on401: () => signInAgain(),
+    on403: () => showPermissionsHelp()
+  }
+});
+```
+
+## React error boundaries
+
+For component-tree errors (rendering, derived state), use Error Boundaries. Boundaries do **not** catch async errors from `sdk.graphql?.()` — those need standard `try / catch` or Promise `.catch()`. Use both layered.
+
+```tsx
+class RecipeBoundary extends React.Component<
+  React.PropsWithChildren,
+  { error: Error | null }
+> {
+  state = { error: null as Error | null };
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("Boundary caught:", error, info);
+  }
+  render() {
+    if (this.state.error) {
+      return <ErrorState message={this.state.error.message} />;
+    }
+    return this.props.children;
+  }
+}
+```
+
+Wrap recipe pages, not individual fields:
+
+```tsx
+<RecipeBoundary>
+  <SingleRecord />
+</RecipeBoundary>
+```
+
+## Loading / empty / error UI states
+
+Every data-fetching component should handle four states explicitly:
+
+| State | When | What to show |
+|---|---|---|
+| **Loading** | First fetch in flight | Skeleton or spinner — never an empty page |
+| **Error** | `try/catch` triggered | Friendly message + retry button |
+| **Empty** | Fetch succeeded, zero results | Helpful guidance, not a blank list |
+| **Loaded** | Data present | The actual UI |
+
+```tsx
+function ContactsList() {
+  const [state, setState] = useState<{
+    status: "loading" | "error" | "empty" | "loaded";
+    data?: Contact[];
+    error?: string;
+  }>({ status: "loading" });
+
+  useEffect(() => {
+    executeGraphQL<ListContacts>({ query: QUERY })
+      .then(d => {
+        const rows = d.uiapi.query.Contact.edges?.map(e => e?.node) ?? [];
+        setState({
+          status: rows.length ? "loaded" : "empty",
+          data: rows as Contact[]
+        });
+      })
+      .catch(err => {
+        setState({
+          status: "error",
+          error: err instanceof Error ? err.message : "Request failed"
+        });
+      });
+  }, []);
+
+  if (state.status === "loading") return <Skeleton />;
+  if (state.status === "error")   return <ErrorState message={state.error!} />;
+  if (state.status === "empty")   return <EmptyState />;
+  return <Table rows={state.data!} />;
+}
+```
+
+> Use `err instanceof Error`, **not** `(err as Error).message`. The cast tells TypeScript to be quiet; the type guard tells the reader and the type system what's actually being checked.
+
+## Anti-patterns
+
+```ts
+// ❌ Type cast to silence TS — no real check
+.catch(err => setError((err as Error).message))
+
+// ✅ Type guard — narrows safely
+.catch(err => setError(err instanceof Error ? err.message : "Request failed"))
+
+// ❌ Ignoring partial errors when they would mislead
+return response.data;            // even with response.errors set
+
+// ❌ Treating fetch != ok as success
+const res = await sdk.fetch?.("/services/...");
+return await res!.json();        // 401 page becomes garbage JSON
+```
+
+## LWC vs React error handling
+
+| Concern | LWC | React |
+|---|---|---|
+| Tree-level errors | `errorCallback(error, stack)` lifecycle | Error Boundaries (`getDerivedStateFromError` + `componentDidCatch`) |
+| Async data errors | `@wire` returns `{ data, error }` standardized | Promise `try/catch` in async functions |
+| Standardization | Built into the framework | Convention only — pick one strategy and apply consistently |
+
+Reference: the **error-handling** examples in the [Multi-Framework Recipes](https://github.com/trailheadapps/multiframework-recipes) repo cover boundaries, partial errors, and the four UI states above.

--- a/skills/sf-multiframework/references/graphql-workflow.md
+++ b/skills/sf-multiframework/references/graphql-workflow.md
@@ -1,0 +1,250 @@
+# GraphQL Workflow
+
+Multi-Framework apps use the **Salesforce GraphQL UI API** (`uiapi`) for record reads and writes. This guide covers the full type-safe pipeline: schema introspection → codegen → operations → typed call sites.
+
+## Pipeline overview
+
+```
+Connected org
+  │  npm run graphql:schema           (org → schema.graphql)
+  ▼
+schema.graphql                        (gitignored, regenerated)
+  │  npm run graphql:codegen          (schema + operations → types)
+  ▼
+src/api/graphql-operations-types.ts   (generated)
+  │  imported by call sites
+  ▼
+React components
+```
+
+## Step 1 — Generate the schema from a connected org
+
+```bash
+npm run graphql:schema
+```
+
+What it does:
+- Authenticates against the currently authorized org
+- Runs an introspection query
+- Writes `schema.graphql` to the project root
+
+Notes:
+- `schema.graphql` is **not** committed (it's org-specific).
+- Re-run any time the org schema changes (new objects, new fields).
+- Scratch org support is uncertain — sandbox is the safest bet.
+
+## Step 2 — Define operations
+
+### Pattern A — Inline `gql` (simple)
+
+```ts
+import { createDataSDK, gql } from "@salesforce/sdk-data";
+
+const SINGLE_ACCOUNT = gql`
+  query SingleAccount {
+    uiapi {
+      query {
+        Account(first: 1) {
+          edges {
+            node {
+              Id
+              Name { value }
+              Industry { value }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+```
+
+Best for:
+- Recipe / single-component reads
+- No variables, no fragments
+- The lesson should be visible inline
+
+### Pattern B — External `.graphql` file (complex / shared)
+
+```
+src/api/utils/query/listAccountsQuery.graphql
+src/api/utils/mutation/updateAccountMutation.graphql
+```
+
+```graphql
+# listAccountsQuery.graphql
+query ListAccounts($first: Int = 20, $after: String) {
+  uiapi {
+    query {
+      Account(first: $first, after: $after, orderBy: { Name: { order: ASC } }) {
+        edges {
+          node {
+            Id
+            Name { value }
+            Industry { value }
+            BillingCity { value }
+          }
+        }
+        pageInfo { endCursor hasNextPage }
+      }
+    }
+  }
+}
+```
+
+Best for:
+- Queries with variables, fragments, or shared use across files
+- Anything codegen should produce types for
+
+## Step 3 — Generate types
+
+```bash
+npm run graphql:codegen
+```
+
+This reads `codegen.yml` and emits `src/api/graphql-operations-types.ts` containing:
+
+- `<OperationName>Query` / `<OperationName>Mutation` — response type
+- `<OperationName>QueryVariables` / `<OperationName>MutationVariables` — variables type
+
+### `codegen.yml` essentials
+
+```yaml
+schema: ./schema.graphql
+documents:
+  - "src/**/*.graphql"
+  - "src/**/*.ts"
+  - "src/**/*.tsx"
+generates:
+  src/api/graphql-operations-types.ts:
+    plugins:
+      - typescript
+      - typescript-operations
+    config:
+      scalars:
+        Currency:        string
+        Date:            string
+        DateTime:        string
+        Email:           string
+        EncryptedString: string
+        Long:            number
+        MultiPicklist:   string
+        Percent:         number
+        Phone:           string
+        Picklist:        string
+        TextArea:        string
+        Time:            string
+        Url:             string
+```
+
+The full UI API scalar list is critical — without it, codegen falls back to `any` for many fields. The `multiframework-recipes` `codegen.yml` is a known-good template.
+
+## Step 4 — Use typed operations
+
+### External file usage
+
+```tsx
+import QUERY from "./query/listAccountsQuery.graphql?raw";
+import type {
+  ListAccountsQuery,
+  ListAccountsQueryVariables,
+  NodeOfConnection
+} from "../graphql-operations-types";
+import { executeGraphQL } from "../graphqlClient";
+
+type AccountNode = NodeOfConnection<
+  NonNullable<ListAccountsQuery["uiapi"]>["query"]["Account"]
+>;
+
+export async function getAccounts(first: number) {
+  const data = await executeGraphQL<ListAccountsQuery, ListAccountsQueryVariables>({
+    query: QUERY,
+    variables: { first }
+  });
+  return data.uiapi.query.Account.edges?.map(e => e?.node) ?? [];
+}
+```
+
+`?raw` is a Vite import suffix that gives you the file as a string.
+
+### Inline usage
+
+```tsx
+import { createDataSDK, gql } from "@salesforce/sdk-data";
+
+const QUERY = gql`
+  query SingleAccount {
+    uiapi { query { Account(first: 1) { edges { node { Id Name { value } } } } } }
+  }
+`;
+
+const sdk = await createDataSDK();
+const data = await sdk.graphql?.(QUERY);
+```
+
+For inline `gql` queries, codegen still picks up the operation if your `documents` glob includes `.ts` / `.tsx`.
+
+## Mutations
+
+```graphql
+# updateAccountMutation.graphql
+mutation UpdateAccount($input: AccountUpdateInput!) {
+  uiapi {
+    AccountUpdate(input: $input) {
+      Record {
+        Id
+        Name { value }
+        Industry { value }
+      }
+    }
+  }
+}
+```
+
+Mutation input types follow the pattern `<ObjectName>CreateInput` / `<ObjectName>UpdateInput`. Search the schema first:
+
+```bash
+# Find available fields
+rg "type Account implements Record" schema.graphql
+
+# Find filter / sort / input options
+rg "input Account_Filter|input Account_OrderBy|input AccountUpdateInput" schema.graphql
+```
+
+> Some fields **cannot be returned** from a mutation. If you get partial data + errors back, use the **Permissive** error strategy or remove the offending fields from the return shape. See [error-handling.md](error-handling.md).
+
+## Schema exploration tips
+
+When designing a query, search `schema.graphql`:
+
+| You need | Search pattern |
+|---|---|
+| Available fields on an object | `type <ObjectName> implements Record` |
+| Filter inputs | `input <ObjectName>_Filter` |
+| Order-by inputs | `input <ObjectName>_OrderBy` |
+| Mutation create/update inputs | `input <ObjectName>CreateInput` / `input <ObjectName>UpdateInput` |
+| Connections | `type <ObjectName>Connection` |
+
+## Recipe vs production patterns
+
+`multiframework-recipes` ships an **explicit anti-pattern guidance**: in **recipes**, queries should be **inline `gql`** so the lesson is visible top-to-bottom. In **production code**, `.graphql` files + codegen are usually the better choice for shared operations.
+
+Choose per use case:
+
+| Use case | Pattern |
+|---|---|
+| Educational recipe / docs example | Inline `gql` |
+| One-off component, no variables | Inline `gql` |
+| Shared list query used by 3+ pages | External `.graphql` + codegen |
+| Mutation with complex input | External `.graphql` + codegen |
+
+## Common GraphQL errors and fixes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Codegen produces empty types file | `schema.graphql` missing | `npm run graphql:schema` |
+| `Property 'value' does not exist on type 'string'` | Forgot the `{ value }` wrapper | Read field as `record.Name.value` |
+| `edges` is `null` despite data | Filter excluded everything; pageInfo / size mismatch | Drop filter, narrow with explicit field args |
+| Mutation succeeds but errors mention a return field | Field can't be selected on mutation return | Remove that field from the mutation, or switch to Permissive |
+| Codegen types fall back to `any` | Scalar mappings missing in `codegen.yml` | Add full UIAPI scalar list (see above) |
+| `gql` template highlights nothing | GraphQL ESLint plugin / extension not configured | Install `@graphql-eslint/eslint-plugin` and configure |

--- a/skills/sf-multiframework/references/lwc-vs-react.md
+++ b/skills/sf-multiframework/references/lwc-vs-react.md
@@ -1,0 +1,96 @@
+# React (Multi-Framework) vs LWC
+
+Multi-Framework **broadens developer choice**; it does not replace LWC. They serve different purposes. Use this guide to decide which framework fits a given task on the Salesforce Platform.
+
+## TL;DR decision tree
+
+```
+Will this be embedded inside Lightning Experience, an Experience Builder site,
+or the Salesforce mobile app as a reusable component?
+  ├─ yes → LWC
+  └─ no
+      Is this a self-contained SPA or a custom-branded portal?
+      ├─ yes → React (Multi-Framework)
+      └─ no
+          Do you need a specific React library (charting, mapping, code editor, etc.)?
+          ├─ yes → React
+          └─ no  → LWC (default for platform integration)
+```
+
+## Side-by-side
+
+| Concern | LWC | React (Multi-Framework Beta) |
+|---|---|---|
+| **Integration with the platform** | Deep & native — automatic data binding, Lightning Data Service, Apex, page editor placement | Hosted on the platform, but app-shaped — UI Bundle is one atomic unit |
+| **Performance inside Salesforce UI** | Optimized for the platform; usually best inside Lightning Experience | High performance for complex UIs; depends on API design and data fetching |
+| **Security & governance** | Platform-enforced; CRUD/FLS, Locker/Lightning Web Security, secure component model | App-level — you own security best practices and secure API calls |
+| **Component reuse across orgs/contexts** | Excellent at component-level reuse inside Salesforce | Component reuse is great inside the React app; Micro-Frontend support for cross-context is Developer Preview |
+| **Learning curve** | Low for modern JS/HTML developers; standards-based | Low–moderate, depending on familiarity with React + ecosystem |
+| **Ecosystem** | Lightning base components, `@wire`, lwc-recipes | All of npm; React 19; Vite; React Router 7; shadcn; etc. |
+| **Styling** | Auto-applied SLDS via base components | SLDS blueprints, `design-system-react`, or Tailwind/shadcn — you choose |
+| **Data access** | LDS, `@wire`, Apex `@AuraEnabled` | `@salesforce/sdk-data` (GraphQL UI API + `fetch` allow-list) |
+| **Build / deploy** | First-class metadata, `sf project deploy` | UIBundle metadata; build artifacts in `dist/` ship with the bundle |
+| **Available surfaces** | Lightning Experience, Experience Cloud (LWR + Aura), Mobile app, Page templates, Flow Screens, App Builder | App Launcher (`AppLauncher`) or Experience Cloud site (`Experience`) |
+| **Embedding inside another framework** | Native | Hosted alone (cross-framework via Micro-Frontends Developer Preview) |
+| **Languages** | Standard JS/TS, HTML templates | TypeScript / JSX |
+| **Dark mode / theming** | Built-in via SLDS 2 tokens | DIY via Tailwind tokens or SLDS 2 |
+| **Org enablement** | GA, no toggle | Beta toggle in sandbox/scratch only; **cannot be disabled** once enabled |
+
+## Pick LWC when…
+
+- You're building a **reusable component** that will be placed in record pages, list views, app pages, or App Builder.
+- You need automatic SLDS, automatic accessibility from base components, and the latest design system updates.
+- You want first-class platform integrations: `@wire`, `lightning/uiRecordApi`, Apex `@AuraEnabled`, `lightning/navigation`.
+- You're building for **Salesforce mobile** with native rendering.
+- You want platform-managed security policies (Locker / LWS) without writing them yourself.
+- The unit of work is a **component**, not an **app**.
+
+## Pick React when…
+
+- You're building a **self-contained SPA** that uses Salesforce as a host and data source.
+- You want a **custom-branded portal** (B2B / B2C) with specific UX requirements that don't fit Lightning conventions.
+- You want a specific React library (data grid, charts, code editor, video player, etc.).
+- Your team already has deep React expertise and you want to minimize ramp-up.
+- The unit of work is an **app**, not a component.
+- You can accept Beta limitations (sandbox/scratch only, English orgs, can't disable).
+
+## Specific scenarios
+
+| Scenario | Choice | Reason |
+|---|---|---|
+| Custom record-page tile showing related contacts | **LWC** | Embeds in the record page; needs `@wire` and Lightning navigation |
+| Customer self-service portal with login, profile, support cases | **React** (`Experience` target) | Self-contained SPA with custom branding |
+| Internal sales productivity app with charts and complex tables | **React** (`AppLauncher` target) | Use a charting library + custom layout |
+| Form embedded in a Flow screen | **LWC** | Flow screens take LWCs natively, not React |
+| Mobile-first field service interface | **LWC** | Salesforce Mobile App native rendering |
+| Custom dashboard with shadcn UI + Tailwind | **React** | Design system fits poorly inside SLDS |
+| Embedding an Agentforce chat in a custom UI | **Either** — both can host ACC | Pick based on the rest of the surface |
+
+## Frequently confused points
+
+### "Can I use both in the same org?"
+Yes. They coexist. A React app can sit alongside LWC apps and components. They don't share state or styling automatically — treat them as independent surfaces.
+
+### "Can I embed an LWC inside a React app?"
+Not directly today. Cross-framework embedding is Developer Preview via the Micro-Frontends path. The supported pattern is to **embed an LWCI** (like ACC) inside a React app, not arbitrary LWCs.
+
+### "Can I embed a React app inside an LWC?"
+Not in the supported way. The opposite direction (LWCI inside React) is the supported flow.
+
+### "Will React replace LWC?"
+No. Salesforce positions LWC as the primary framework for platform-integrated components and React (and future frameworks) for **self-contained SPAs and custom experiences**.
+
+### "Is the Beta production-ready?"
+Beta. Sandbox/scratch only, English-only, can't be disabled. Plan production rollout against GA timelines.
+
+## Migration thinking
+
+You generally shouldn't **migrate** from LWC to React for a working component. The cost rarely pays back. Use React for **new apps** where its strengths apply. Keep LWC for component-shaped surfaces in the platform UI.
+
+If you're thinking about migrating because LWC is "limiting", first check whether the limitation is real: many "I need React for this" cases are solvable with LWC + a well-chosen npm dep (chart libraries, date pickers, etc.) loaded via Lightning Web Security.
+
+## See also
+
+- [overview.md](overview.md) — what Multi-Framework is and isn't
+- [setup.md](setup.md) — Beta org configuration
+- Official: [React vs LWC (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-lwc-diff.html)

--- a/skills/sf-multiframework/references/official-sources.md
+++ b/skills/sf-multiframework/references/official-sources.md
@@ -1,0 +1,75 @@
+# Official Sources
+
+The authoritative documentation and reference implementations this skill is distilled from. Cite these when you need to back up a claim or check the current state of the Beta.
+
+## Salesforce Developer Documentation (Beta)
+
+### Overview & Setup
+- [Build a React App with Salesforce Multi-Framework (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-overview.html)
+- [Configure Your Org for React App Development (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-setup.html)
+
+### Project Mechanics
+- [Integrate Your React App with the Agentforce 360 Platform (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-integrate.html) — `UIBundle`, `ui-bundle.json`, `.uibundle-meta.xml`, templates
+- [Develop a React App Manually (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-develop.html) — manual authoring path
+
+### Data SDK & GraphQL
+- [Data SDK and GraphQL (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-data-sdk.html)
+- [Access Record Data with Data SDK (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-data-sdk-usage.html)
+- [Error Handling in Data SDK (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-data-sdk-graphql-error.html)
+
+### UI / Experience
+- [Style Your React Apps (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-styling.html)
+- [Integrate Agentforce Conversation Client in Your React App (Beta)](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-acc.html)
+
+### Decisions
+- [React vs LWC (Beta)](https://developer.salesforce.com/docs/platform/code-builder/guide/reactdev-lwc-diff.html)
+
+## Reference Implementations
+
+### `multiframework-recipes`
+- [GitHub: trailheadapps/multiframework-recipes](https://github.com/trailheadapps/multiframework-recipes) — canonical recipe set
+- [`AGENT.md`](https://raw.githubusercontent.com/trailheadapps/multiframework-recipes/main/AGENT.md) — developer & agent guide for the recipe repo (the source of most recipe conventions in this skill)
+- Key directories:
+  - `force-app/main/react-recipes/uiBundles/reactRecipes/` — the React app
+  - `force-app/main/default/` — shared metadata (objects, classes, permission sets)
+  - `data/` — sample data tree plans
+
+## Salesforce CLI Reference
+
+- [Salesforce CLI Command Reference: ui-bundle Commands](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_ui-bundle.htm)
+- [Salesforce CLI Command Reference: template generate ui-bundle](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_template_generate_ui-bundle.htm)
+- [Salesforce CLI Command Reference: template generate project](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_template_generate_project.htm)
+
+## Metadata API
+
+- [Metadata API Developer Guide: UIBundle](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_uibundle.htm)
+- [Salesforce DX Project Structure and Source Format](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_source_file_format.htm)
+
+## Related Salesforce Docs
+
+- [Lightning Types in Agent Action](https://developer.salesforce.com/docs/) — used by ACC for dynamic component rendering
+- [Agentforce Conversation Client Developer Guide](https://developer.salesforce.com/docs/) — standalone (external apps)
+- [Agentforce Vibes Setup](https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/) — for AI-assisted authoring
+- [Salesforce Multi-Framework Developer Guide](https://developer.salesforce.com/docs/) — landing page
+
+## npm Packages
+
+| Package | Purpose |
+|---|---|
+| [`@salesforce/sdk-data`](https://www.npmjs.com/package/@salesforce/sdk-data) | Data SDK (`createDataSDK`, `gql`, `NodeOfConnection`) |
+| [`@salesforce/agentforce-conversation-client`](https://www.npmjs.com/package/@salesforce/agentforce-conversation-client) | ACC widget for embedding chat |
+| [`@salesforce/vite-plugin-ui-bundle`](https://www.npmjs.com/package/@salesforce/vite-plugin-ui-bundle) | Vite dev server integration |
+| [`@salesforce/ui-bundle`](https://www.npmjs.com/package/@salesforce/ui-bundle) | Helper functions for the SDK |
+| [`@salesforce-ux/design-system`](https://www.npmjs.com/package/@salesforce-ux/design-system) | SLDS CSS blueprints |
+| [`@salesforce/design-system-react`](https://www.npmjs.com/package/@salesforce/design-system-react) | SLDS React components |
+
+## When to defer to official docs
+
+This skill condenses the docs and adds opinionated patterns from the recipe repo. Defer to the linked official sources when:
+
+- A new Beta release changes the API surface (versions of `@salesforce/sdk-data`, ACC, the Vite plugin)
+- You hit a specific error message you can't find in [troubleshooting.md](troubleshooting.md)
+- The exact SDK option shape (e.g. `createAccWidget` parameters) matters for the bug you're fixing
+- You need to verify a Beta limitation hasn't changed (sandbox-only, English-only, can't disable, etc.)
+
+The skill's posture is: **patterns and decision frameworks** are stable enough to encode here; **exact API shapes** of evolving SDKs should be verified against the installed package.

--- a/skills/sf-multiframework/references/overview.md
+++ b/skills/sf-multiframework/references/overview.md
@@ -1,0 +1,127 @@
+# Overview — Salesforce Multi-Framework (Beta)
+
+> **Sources.** Skill built from Salesforce developer documentation (see [official-sources.md](official-sources.md)) and code patterns from [trailheadapps/multiframework-recipes](https://github.com/trailheadapps/multiframework-recipes). Skill framework adapted from **Jag Valaiyapathy's SF Skills repo** (same rubric, format, and governance conventions used across `sf-*` skills).
+
+## What it is
+
+Salesforce Multi-Framework lets you build apps in non-Lightning UI frameworks — currently **React** — that run on the **Agentforce 360 Platform**. Apps are packaged and deployed as a `UIBundle` metadata type and hosted by the platform alongside CMS content with versioning and publication lifecycle management.
+
+When deployed, a `UIBundle` record:
+
+- declares the app's identity on the platform
+- declares which containers can host it (App Launcher, Experience Cloud)
+- pulls runtime assets, images, and metadata from Salesforce CMS storage
+
+A single `UIBundle` can contain up to **2,500 files**.
+
+## Why it exists
+
+Two audiences benefit:
+
+| Audience | Benefit |
+|---|---|
+| React developers | Reach Salesforce data and authentication without learning the LWC framework |
+| Salesforce developers | Use modern bundlers (Vite), npm packages, and rich UI libraries inside the platform |
+
+The feature is positioned for **self-contained SPAs and highly customized experiences** that use Salesforce as the host and data source — *not* as a replacement for LWC for tightly-integrated platform components.
+
+## How it ships
+
+| Element | Location | Purpose |
+|---|---|---|
+| `UIBundle` metadata | `force-app/main/default/uiBundles/<app>/` | App identity & container declaration |
+| `<app>.uibundle-meta.xml` | bundle root | Metadata definition (target, isActive, version) |
+| `ui-bundle.json` | bundle root | Runtime configuration (output dir, routing, API version) |
+| App source | `src/`, `package.json`, etc. | The React app itself |
+| Build output | `dist/` (Vite default) | What actually gets served at runtime |
+
+## What targets are supported
+
+The `<target>` element in `.uibundle-meta.xml` accepts:
+
+| Target | Effect | Use case |
+|---|---|---|
+| `AppLauncher` (default) | App appears in the App Launcher for authenticated users | Internal employee apps (B2E) |
+| `Experience` | App is served by an Experience Cloud site | External B2B / B2C portals |
+
+## What you can use inside the React app
+
+| Allowed | Not allowed |
+|---|---|
+| Standard web APIs (`fetch` to *non-Salesforce* endpoints, `URL`, etc.) | `lightning/*` modules, Lightning base components |
+| Any npm package | `@wire` decorators |
+| `@salesforce/sdk-data` (Data SDK) | Most other `@salesforce/*` scoped modules |
+| `@salesforce/agentforce-conversation-client` (ACC) | Direct `axios` / `fetch` to Salesforce endpoints |
+| `@salesforce/ui-bundle` helpers | |
+| `@salesforce/vite-plugin-ui-bundle` (dev only) | |
+
+## Beta limitations
+
+- **Sandbox and scratch orgs only** — no DE orgs, no Trailhead Playgrounds.
+- **Default language must be `en_US`** — known issue with non-English orgs.
+- **Once enabled, cannot be disabled** in an org.
+- **One UI bundle per metadata push** is the safe pattern; multi-app deploys can collide.
+- **No Experience Builder editing** for sites attached to React apps.
+- **Currently React only** — additional frameworks planned over time.
+
+## Related platform features
+
+| Feature | Relationship |
+|---|---|
+| **Agentforce Vibes** | AI-assisted authoring inside VS Code; uses skills + rules to scaffold and edit React apps + GraphQL |
+| **Agentforce Conversation Client (ACC)** | Lightning Out 2.0 LWCI you can embed inside the React app for chat with Employee Agents |
+| **Salesforce CMS** | Storage layer for runtime assets and content used inside React apps |
+| **Data 360 / Hybrid Search** | Powers the `search_electronic_media` ACC tool when configured |
+
+## Decision trees
+
+### "Should I use React (Multi-Framework) or LWC?"
+
+Pick LWC when:
+- You're building reusable platform components, especially for Lightning Experience or Salesforce mobile.
+- You need automatic SLDS, Lightning Data Service, or `@wire` integrations.
+- The component will be embedded in record pages, list views, or App Builder.
+
+Pick React when:
+- You're building a self-contained SPA or a custom-branded portal.
+- You need a specific React library (charting, mapping, code editor, etc.).
+- You want a non-Salesforce UI aesthetic (Tailwind, custom design system).
+
+See [lwc-vs-react.md](lwc-vs-react.md) for a structured comparison.
+
+### "Internal or external app?"
+
+Pick `AppLauncher` (internal) when:
+- Users are employees authenticated via Salesforce.
+- The app appears alongside other Lightning apps in the App Launcher.
+- You want the simplest deployment path.
+
+Pick `Experience` (external) when:
+- Users are partners or customers (B2B / B2C).
+- You need a public-facing URL via an Experience Cloud site.
+- You're prepared to maintain `digitalExperienceConfigs`, `digitalExperiences`, `networks`, and `sites` metadata alongside the bundle.
+
+## Workflow at a glance
+
+```
+Setup org (one-time)
+  ├─ Enable Multi-Framework (Beta)
+  ├─ Configure My Domain / Trusted Domains (if using ACC)
+  └─ Authorize org via sf CLI
+
+Scaffold project
+  └─ sf template generate ui-bundle --template reactinternalapp|reactexternalapp
+
+Develop locally
+  ├─ npm install
+  ├─ npm run graphql:schema   (introspect org)
+  ├─ npm run graphql:codegen  (generate types)
+  └─ npm run dev              (Vite + @salesforce/vite-plugin-ui-bundle)
+
+Build & deploy
+  ├─ npm run build            (→ dist/)
+  └─ sf project deploy start --source-dir <bundle>
+
+Verify
+  └─ App Launcher / Digital Experiences / hard-refresh deep links
+```

--- a/skills/sf-multiframework/references/permissions-csp.md
+++ b/skills/sf-multiframework/references/permissions-csp.md
@@ -1,0 +1,208 @@
+# Permissions, Trusted Sites, and Resource Loading
+
+Two separate gates control what a UIBundle app can do in an org:
+
+1. **Permission sets** — who can run the app and what Salesforce data they can access
+2. **CSP Trusted Sites** — which *external* URLs the browser is allowed to load (images, fonts, analytics, Lightning Out hosts for ACC)
+
+Both fail silently in different ways. Plan them upfront.
+
+## Permission sets for UI bundles
+
+At minimum your end users need:
+
+| Permission | Who needs it | Why |
+|---|---|---|
+| Object-level read/edit on data the app queries | every user | GraphQL queries enforce org FLS/CRUD |
+| Field-level read/edit for every field in GraphQL queries | every user | Missing FLS returns `null` in UI API, not an error |
+| `ViewSetup` (if app deep-links into Setup) | admins only | Rare |
+| System permission to view the bundle itself (if restricted) | every user | Default is usually public within the org |
+| For **ACC**: `Agentforce` permission + the agent's `<agentAccesses>` | every user using chat | Without `<agentAccesses>` in a permission set, the agent is invisible |
+
+See [`sf-permissions`](../../sf-permissions/SKILL.md) for permission-set design, `<agentAccesses>` grants, and audit patterns.
+
+### Starter permission set (`force-app/main/default/permissionsets/myApp.permissionset-meta.xml`)
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>My React App User</label>
+    <hasActivationRequired>false</hasActivationRequired>
+
+    <!-- Object + field access for everything the React app queries -->
+    <objectPermissions>
+        <allowRead>true</allowRead>
+        <allowCreate>true</allowCreate>
+        <allowEdit>true</allowEdit>
+        <object>Account</object>
+    </objectPermissions>
+
+    <fieldPermissions>
+        <field>Account.Industry</field>
+        <readable>true</readable>
+        <editable>true</editable>
+    </fieldPermissions>
+
+    <!-- If the app has its own tab entry in App Launcher -->
+    <tabSettings>
+        <tab>MyReactApp</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+</PermissionSet>
+```
+
+### Assign at scratch-org setup
+
+```bash
+sf org create scratch --definition-file config/project-scratch-def.json --alias devorg --set-default
+sf project deploy start --source-dir force-app
+sf org assign permset --name myApp
+```
+
+### Silent FLS failures
+
+UI API GraphQL does not throw on missing field access — it returns `null` in the `{ value }` wrapper. If a field is suddenly blank in production but works in dev, check FLS first. Symptom:
+
+```js
+account.Phone.value  // → null   (field not readable for this user)
+account.Phone        // → { value: null }   (field readable, value is empty)
+```
+
+Same wire-level shape, different cause. Add FLS before blaming the query.
+
+## CSP Trusted Sites
+
+Salesforce's Content Security Policy blocks *all* cross-origin requests from the host frame by default. Every non-Salesforce URL — image CDNs, analytics, fonts from Google Fonts, Lightning Out hosts, etc. — needs a `CspTrustedSite` metadata record.
+
+### When you need one
+
+| Loading… | Needs `CspTrustedSite`? |
+|---|---|
+| Images from an S3 bucket | yes (`isApplicableToImgSrc`) |
+| Google Fonts stylesheets | yes (`isApplicableToStyleSrc` + `isApplicableToFontSrc`) |
+| Analytics script (Segment, Amplitude, Plausible) | yes (`isApplicableToScriptSrc` + `isApplicableToConnectSrc`) |
+| Third-party API via `fetch()` from the React app | yes (`isApplicableToConnectSrc`) — **but prefer a Named Credential + Apex REST** |
+| Embedded iframe (e.g. external auth) | yes (`isApplicableToFrameSrc`) — ACC is a special case: see below |
+
+### Metadata example
+
+```xml
+<!-- force-app/main/default/cspTrustedSites/AmazonS3Media.cspTrustedSite-meta.xml -->
+<?xml version="1.0" encoding="UTF-8" ?>
+<CspTrustedSite xmlns="http://soap.sforce.com/2006/04/metadata">
+    <context>All</context>
+    <description>App media hosted in S3</description>
+    <endpointUrl>https://my-bucket.s3.us-west-2.amazonaws.com</endpointUrl>
+    <isActive>true</isActive>
+    <isApplicableToImgSrc>true</isApplicableToImgSrc>
+    <isApplicableToConnectSrc>false</isApplicableToConnectSrc>
+    <isApplicableToFontSrc>false</isApplicableToFontSrc>
+    <isApplicableToFrameSrc>false</isApplicableToFrameSrc>
+    <isApplicableToMediaSrc>false</isApplicableToMediaSrc>
+    <isApplicableToStyleSrc>false</isApplicableToStyleSrc>
+    <canAccessCamera>false</canAccessCamera>
+    <canAccessMicrophone>false</canAccessMicrophone>
+</CspTrustedSite>
+```
+
+Each `isApplicableTo*` flag maps to a CSP directive:
+
+| Flag | Browser directive | Example resource |
+|---|---|---|
+| `isApplicableToImgSrc` | `img-src` | `<img src>`, `background-image: url(...)` |
+| `isApplicableToStyleSrc` | `style-src` | `<link rel="stylesheet">` |
+| `isApplicableToFontSrc` | `font-src` | `@font-face { src: url(...) }` |
+| `isApplicableToScriptSrc` | `script-src` | `<script src>` |
+| `isApplicableToConnectSrc` | `connect-src` | `fetch()`, `XMLHttpRequest`, WebSocket |
+| `isApplicableToFrameSrc` | `frame-src` | `<iframe src>` |
+| `isApplicableToMediaSrc` | `media-src` | `<audio>`, `<video>` |
+
+Only enable the flags you actually need — each widens the attack surface.
+
+### Common combos
+
+**Google Fonts**
+
+```xml
+<endpointUrl>https://fonts.googleapis.com</endpointUrl>
+<isApplicableToStyleSrc>true</isApplicableToStyleSrc>
+```
+
+```xml
+<endpointUrl>https://fonts.gstatic.com</endpointUrl>
+<isApplicableToFontSrc>true</isApplicableToFontSrc>
+```
+
+Two sites because Google splits the CSS from the font files.
+
+**Image CDN**
+
+```xml
+<endpointUrl>https://cdn.example.com</endpointUrl>
+<isApplicableToImgSrc>true</isApplicableToImgSrc>
+```
+
+**Analytics that loads a script + sends data**
+
+```xml
+<endpointUrl>https://cdn.segment.com</endpointUrl>
+<isApplicableToScriptSrc>true</isApplicableToScriptSrc>
+```
+
+```xml
+<endpointUrl>https://api.segment.io</endpointUrl>
+<isApplicableToConnectSrc>true</isApplicableToConnectSrc>
+```
+
+## ACC (iframe hosts) — the `frame-src` case
+
+The Agentforce Conversation Client loads Lightning Out into an iframe. For local dev, that iframe's origin is the dev server URL (`http://localhost:5173`). Two configurations need to line up:
+
+1. **Trusted Domains for Inline Frames** (Setup → Session Settings) — platform-level allowlist for what can be *host* of an iframe embedding Salesforce. Type **Lightning Out**.
+2. **`CspTrustedSite`** with `isApplicableToFrameSrc: true` — allowlist for what the *React app* is allowed to iframe.
+
+For ACC, **#1 is the one that matters** because the React app is embedding a Salesforce iframe, not the other way around. Full detail in [acc-integration.md](acc-integration.md). Only add a `frame-src` trusted site if the React app embeds a *third-party* iframe (embedded auth, third-party video, etc.).
+
+## `tabSettings` — making the app launch from App Launcher
+
+When the UIBundle target is `AppLauncher`, the platform auto-creates a tab. End users must have it visible in their permission set:
+
+```xml
+<tabSettings>
+    <tab>MyReactApp</tab>          <!-- matches UIBundle developer name -->
+    <visibility>Visible</visibility>
+</tabSettings>
+```
+
+Without this, the bundle deploys and the tab exists in metadata, but users don't see it in App Launcher.
+
+## Diagnosing CSP blocks
+
+Browser DevTools → Console prints CSP violations in full:
+
+```
+Refused to load the image 'https://cdn.example.com/foo.png' because it violates
+the following Content Security Policy directive: "img-src ...".
+```
+
+Key facts from the message:
+- the **directive name** (`img-src`) → maps to `isApplicableToImg`
+- the **URL origin** (`https://cdn.example.com`) → the `endpointUrl`
+
+Add a matching `CspTrustedSite`, redeploy, hard-refresh. CSP is cached — sometimes a Ctrl+Shift+R or new incognito window is needed.
+
+## What NOT to do
+
+- ❌ Don't set `isApplicableToConnectSrc: true` as a shotgun fix — that grants `fetch()` permission to the origin, which is rarely what you want. Use a Named Credential + Apex REST for outbound data calls.
+- ❌ Don't manage third-party API auth inside the React app. Named Credential + Apex REST keeps secrets server-side.
+- ❌ Don't deploy a permission set with `objectPermissions` but no `fieldPermissions` — UI API queries will return `null` for every field and users will see empty data.
+- ❌ Don't rely on profile-level permissions in new work. Permission sets are the supported path for UI bundle access.
+
+## Cross-skill handoff
+
+| Task | Skill |
+|---|---|
+| Permission-set design / audit / hierarchy | [sf-permissions](../../sf-permissions/SKILL.md) |
+| Named Credentials for third-party APIs | [sf-integration](../../sf-integration/SKILL.md) |
+| Apex REST endpoints for server-side calls | [sf-apex](../../sf-apex/SKILL.md) |
+| ACC iframe + cookie configuration | [acc-integration.md](acc-integration.md) |

--- a/skills/sf-multiframework/references/project-structure.md
+++ b/skills/sf-multiframework/references/project-structure.md
@@ -1,0 +1,192 @@
+# Project Structure
+
+A Multi-Framework app is a **self-contained unit** under `force-app/main/default/uiBundles/<appName>/` containing both metadata and source. Application metadata and content live together — there is no separation between "Salesforce metadata" and "frontend source" the way there is for LWC.
+
+## Canonical layout
+
+```
+multiframework-recipes/
+  sfdx-project.json                 # Salesforce DX config (apiVersion v66.0)
+  package.json                      # ROOT — SFDX metadata scripts only, NOT the React app
+  data/                             # sf data import tree plans
+  config/project-scratch-def.json   # MUST set "language": "en_US"
+  force-app/main/default/
+    uiBundles/
+      myApp/                        # ← the entire React app + metadata
+        myApp.uibundle-meta.xml     # UIBundle metadata definition
+        ui-bundle.json              # Runtime configuration (routing, output dir)
+        package.json                # React app dependencies (separate from root)
+        vite.config.ts              # Vite + @salesforce/vite-plugin-ui-bundle
+        tsconfig.json
+        codegen.yml                 # GraphQL codegen config
+        schema.graphql              # Generated from connected org (gitignored)
+        scripts/
+          get-graphql-schema.mjs    # Introspection helper
+        src/
+          app.tsx                   # Router + providers
+          appLayout.tsx             # Shell (Navbar + <Outlet />)
+          routes.tsx                # Route definitions
+          api/
+            graphqlClient.ts        # executeGraphQL wrapper
+            graphql-operations-types.ts  # Generated types
+            utils/
+              query/                # .graphql read queries
+              mutation/             # .graphql write mutations
+          components/
+            app/                    # Navbar, Layout, CodeBlock
+            recipe/                 # Shared recipe UI (Skeleton, ContactTile)
+            ui/                     # shadcn/ui primitives
+          pages/                    # Route pages
+          recipes/                  # Recipe components by category
+          lib/                      # cn(), utilities
+          styles/
+            global.css              # Tailwind + design tokens
+            slds.css                # SLDS imports
+          assets/                   # Icons, images
+        dist/                       # ← BUILD OUTPUT — what gets deployed
+```
+
+> Two `package.json` files are intentional. The root one is for SFDX scripts. The bundle one is for the React app. **Do not merge them.**
+
+## Required files at the bundle root
+
+### `<appName>.uibundle-meta.xml`
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<UIBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <isActive>true</isActive>
+    <masterLabel>My App</masterLabel>
+    <target>AppLauncher</target>
+    <version>1.0.0</version>
+</UIBundle>
+```
+
+| Element | Notes |
+|---|---|
+| `isActive` | Set `true` to make the app available |
+| `masterLabel` | User-facing label |
+| `target` | `AppLauncher` (default) or `Experience` |
+| `version` | App version string |
+
+> External apps must use `<target>Experience</target>` and ship matching `digitalExperiences/`, `networks/`, and `sites/` metadata. See [templates.md](templates.md).
+
+### `ui-bundle.json`
+
+Runtime configuration consumed by the platform when serving the app.
+
+```json
+{
+  "outputDir": "dist",
+  "apiVersion": "v66.0",
+  "routing": {
+    "fileBasedRouting": true,
+    "trailingSlash": "never",
+    "fallback": "index.html",
+    "rewrites": [
+      { "route": "/api/*", "target": "/api/index.html" }
+    ],
+    "redirects": [
+      { "route": "/old", "target": "/new", "statusCode": "301" }
+    ]
+  }
+}
+```
+
+#### Property reference
+
+| Property | Type | Required | Notes |
+|---|---|---|---|
+| `outputDir` | string | yes | Path relative to bundle root containing build artifacts. Vite default is `dist`. |
+| `apiVersion` | string | recommended | Format `vXX.X`. Match the deploy target. Defaults to current org version. |
+| `routing.fileBasedRouting` | boolean | no | When `true`, URLs map to folder structure inside `outputDir`. Default `true`. |
+| `routing.trailingSlash` | enum | no | `never` removes (`/page/` → `/page`); `always` adds; `auto` no change. |
+| `routing.fallback` | string | **yes for SPAs** | File served when nothing matches. Set `index.html` for client-side routing. |
+| `routing.rewrites` | array | no | Internal rewrite rules — change file served without changing URL. Supports `:id` and `*`. |
+| `routing.redirects` | array | no | HTTP redirects with status `301` / `302` / `307` / `308`. Evaluated in order. |
+| `routing.rewrites.route` / `.target` | string | yes | Source pattern → internal file path |
+| `routing.redirects.route` / `.target` / `.statusCode` | string | yes | Source pattern → destination URL → HTTP status |
+
+#### SPA-minimal `ui-bundle.json`
+
+```json
+{
+  "outputDir": "dist",
+  "apiVersion": "v66.0",
+  "routing": {
+    "fallback": "index.html",
+    "trailingSlash": "never"
+  }
+}
+```
+
+### `package.json` (bundle)
+
+The bundle's `package.json` declares React app dependencies and scripts. Typical scripts:
+
+```json
+{
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint .",
+    "test": "vitest",
+    "test:coverage": "vitest --coverage",
+    "test:e2e": "playwright test",
+    "graphql:schema": "node scripts/get-graphql-schema.mjs",
+    "graphql:codegen": "graphql-codegen --config codegen.yml"
+  }
+}
+```
+
+Recommended Vite plugins for any non-template-scaffolded project:
+
+- `@salesforce/vite-plugin-ui-bundle` — wires Vite dev server to the org for live data
+- `@salesforce/ui-bundle` — helper functions (auth, base path) for working with the Data SDK
+
+## File-count budget
+
+A `UIBundle` can hold up to **2,500 files**. Source maps in `dist/` and large public asset folders are the usual culprits when you hit the ceiling. Configure Vite to emit fewer source maps in production if needed:
+
+```ts
+// vite.config.ts
+build: {
+  sourcemap: false   // or 'hidden' to keep them but not reference in output
+}
+```
+
+## Path aliases (recommended)
+
+Define matching aliases in **both** `vite.config.ts` and `tsconfig.json` to keep imports tidy:
+
+```ts
+// vite.config.ts
+resolve: {
+  alias: {
+    "@": "/src",
+    "@api": "/src/api",
+    "@components": "/src/components",
+    "@utils": "/src/utils",
+    "@styles": "/src/styles",
+    "@assets": "/src/assets"
+  }
+}
+```
+
+```json
+// tsconfig.json (compilerOptions)
+"baseUrl": ".",
+"paths": {
+  "@/*":          ["src/*"],
+  "@api/*":       ["src/api/*"],
+  "@components/*":["src/components/*"],
+  "@utils/*":     ["src/utils/*"],
+  "@styles/*":    ["src/styles/*"],
+  "@assets/*":    ["src/assets/*"]
+}
+```
+
+## Why the bundle is self-contained
+
+The platform treats `uiBundles/<appName>/` as one atomic unit. Deploys ship the metadata + the contents of `outputDir` together. Sharing source between bundles is **not** supported — you can't import from a sibling bundle. Use npm packages for genuine code sharing.

--- a/skills/sf-multiframework/references/project-structure.md
+++ b/skills/sf-multiframework/references/project-structure.md
@@ -78,7 +78,6 @@ Runtime configuration consumed by the platform when serving the app.
 ```json
 {
   "outputDir": "dist",
-  "apiVersion": "v66.0",
   "routing": {
     "fileBasedRouting": true,
     "trailingSlash": "never",
@@ -98,7 +97,6 @@ Runtime configuration consumed by the platform when serving the app.
 | Property | Type | Required | Notes |
 |---|---|---|---|
 | `outputDir` | string | yes | Path relative to bundle root containing build artifacts. Vite default is `dist`. |
-| `apiVersion` | string | recommended | Format `vXX.X`. Match the deploy target. Defaults to current org version. |
 | `routing.fileBasedRouting` | boolean | no | When `true`, URLs map to folder structure inside `outputDir`. Default `true`. |
 | `routing.trailingSlash` | enum | no | `never` removes (`/page/` → `/page`); `always` adds; `auto` no change. |
 | `routing.fallback` | string | **yes for SPAs** | File served when nothing matches. Set `index.html` for client-side routing. |
@@ -112,7 +110,6 @@ Runtime configuration consumed by the platform when serving the app.
 ```json
 {
   "outputDir": "dist",
-  "apiVersion": "v66.0",
   "routing": {
     "fallback": "index.html",
     "trailingSlash": "never"
@@ -128,7 +125,7 @@ The bundle's `package.json` declares React app dependencies and scripts. Typical
 {
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "lint": "eslint .",
     "test": "vitest",
@@ -140,10 +137,25 @@ The bundle's `package.json` declares React app dependencies and scripts. Typical
 }
 ```
 
+Prefer `tsc --noEmit && vite build` unless you intentionally configure TypeScript project references. `tsc -b` can emit `*.tsbuildinfo`, `vite.config.js`, and `vite.config.d.ts` at the bundle root, and those files are treated as deployable `UIBundle` members unless ignored or removed.
+
 Recommended Vite plugins for any non-template-scaffolded project:
 
 - `@salesforce/vite-plugin-ui-bundle` — wires Vite dev server to the org for live data
 - `@salesforce/ui-bundle` — helper functions (auth, base path) for working with the Data SDK
+
+### Version compatibility note
+
+Salesforce's Vite plugin can lag the latest Vite major. If `npm install` fails with a peer conflict where `@salesforce/vite-plugin-ui-bundle` wants Vite 7 but `@vitejs/plugin-react` wants Vite 8, pin compatible majors, for example:
+
+```json
+{
+  "devDependencies": {
+    "@vitejs/plugin-react": "^5.2.0",
+    "vite": "^7.3.2"
+  }
+}
+```
 
 ## File-count budget
 

--- a/skills/sf-multiframework/references/react-router.md
+++ b/skills/sf-multiframework/references/react-router.md
@@ -1,0 +1,227 @@
+# React Router 7 on Salesforce Multi-Framework
+
+Multi-Framework apps use **React Router 7**. Two things are non-obvious vs plain-web React Router:
+
+1. The import path changed in v7 — use `react-router`, not `react-router-dom`.
+2. The platform injects a base path at runtime that the router must pick up, or deep links and navigation break inside Lightning Experience / Experience Cloud.
+
+## Install and import
+
+```bash
+npm install react-router
+```
+
+```tsx
+// ✅ correct — v7 consolidated everything into the main package
+import { createBrowserRouter, RouterProvider, Link, NavLink, Outlet, useNavigate, useParams, useLocation } from "react-router";
+
+// ❌ wrong — v6 pattern, missing types + outdated
+import { BrowserRouter } from "react-router-dom";
+```
+
+## The `SFDC_ENV.basePath` contract
+
+At runtime, Salesforce mounts the app under a URL like:
+
+```
+/lwr/application/ai/c-myApp            # Lightning Experience (internal)
+/<site>/s/c-myApp                       # Experience Cloud (external)
+```
+
+The platform sets `globalThis.SFDC_ENV.basePath` so the app knows where it is mounted. The router must use that as its `basename`, otherwise:
+
+- hard refreshes on nested routes (e.g. `/read-data/001XXX`) return 404
+- `Link` / `navigate` produce URLs that double-prefix the base path
+- `useLocation().pathname` doesn't match route definitions
+
+### Canonical entry point
+
+```tsx
+// src/app.tsx
+import { createBrowserRouter, RouterProvider } from "react-router";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { routes } from "./routes";
+import "./styles/global.css";
+import "./styles/slds.css";
+
+// Strip any trailing slash so the basename matches route paths like "/read-data"
+const rawBasePath = (globalThis as any).SFDC_ENV?.basePath;
+const basename =
+  typeof rawBasePath === "string" ? rawBasePath.replace(/\/+$/, "") : undefined;
+
+const router = createBrowserRouter(routes, { basename });
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <RouterProvider router={router} />
+  </StrictMode>
+);
+```
+
+If `SFDC_ENV` is undefined (running outside an org surface, e.g. `vite preview`), `basename` stays `undefined` and the router uses `/` — this is what lets local dev work without conditionals.
+
+## `ui-bundle.json` must match router config
+
+React Router does client-side routing; the platform has to serve `index.html` for every path, otherwise hard-refreshing a non-root route returns 404.
+
+```json
+{
+  "outputDir": "dist",
+  "routing": {
+    "fileBasedRouting": true,
+    "trailingSlash": "never",
+    "fallback": "index.html"
+  }
+}
+```
+
+The three fields that matter:
+
+| Field | Required for SPA | Why |
+|---|---|---|
+| `routing.fallback: "index.html"` | yes | Platform serves the shell on every unmatched path → client router takes over |
+| `routing.trailingSlash: "never"` | recommended | Matches how React Router emits URLs; avoids dupes |
+| `routing.fileBasedRouting` | depends | `true` maps `public/*.html` files to routes; most React SPAs keep it on because the root `index.html` still matters |
+
+## Route definition pattern
+
+Keep routes in `src/routes.tsx` as `RouteObject[]`, not JSX. This is the shape `createBrowserRouter` expects, and it makes routes inspectable:
+
+```tsx
+// src/routes.tsx
+import type { RouteObject } from "react-router";
+import AppLayout from "@/appLayout";
+import Home from "./pages/Home";
+import NotFound from "./pages/NotFound";
+import ReadData from "./pages/ReadData";
+import ModifyData from "./pages/ModifyData";
+import { RouteParametersDetail } from "./recipes/routing/RouteParameters";
+
+export const routes: RouteObject[] = [
+  {
+    path: "/",
+    element: <AppLayout />,
+    children: [
+      { index: true, element: <Home /> },
+      {
+        path: "read-data",
+        element: <ReadData />,
+        handle: { showInNavigation: true, label: "Read Data" },
+      },
+      {
+        path: "modify-data",
+        element: <ModifyData />,
+        handle: { showInNavigation: true, label: "Modify Data" },
+      },
+      {
+        path: "route-parameters",
+        element: <RouteParametersPage />,
+        handle: { showInNavigation: true, label: "Route Parameters" },
+        children: [{ path: ":accountId", element: <RouteParametersDetail /> }],
+      },
+      { path: "*", element: <NotFound /> },
+    ],
+  },
+];
+```
+
+### The `handle` pattern for dynamic navbars
+
+React Router exposes each route's `handle` on `useMatches()`. Use it to drive a navbar without hardcoding the route list in two places:
+
+```tsx
+// appLayout.tsx
+import { useMatches, Outlet, NavLink } from "react-router";
+
+interface NavHandle { showInNavigation?: boolean; label?: string }
+
+export default function AppLayout() {
+  const matches = useMatches();
+  const navRoutes = matches
+    .filter(m => (m.handle as NavHandle | undefined)?.showInNavigation)
+    .map(m => ({ path: m.pathname, label: (m.handle as NavHandle).label ?? m.id }));
+
+  return (
+    <div>
+      <nav>
+        {navRoutes.map(r => (
+          <NavLink key={r.path} to={r.path}>{r.label}</NavLink>
+        ))}
+      </nav>
+      <main>
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+```
+
+## Route parameters
+
+```tsx
+// src/recipes/routing/RouteParameters.tsx
+import { useParams, Link } from "react-router";
+
+export function RouteParametersDetail() {
+  const { accountId } = useParams<{ accountId: string }>();
+  // fetch / render using accountId
+}
+
+// Link into the detail route:
+<Link to={`/route-parameters/${account.Id}`}>{account.Name.value}</Link>
+```
+
+Parameters come back as `string | undefined`. Don't assume they're present — declare the shape with a generic.
+
+## Nested routes with a shared layout
+
+```tsx
+{
+  path: "nested-routes",
+  element: <NestedRoutesPage />,   // page shell (headings, chrome)
+  children: [
+    {
+      element: <NestedRoutes />,   // layout for the nested section
+      children: [
+        { index: true, element: <NestedRoutesIndex /> },
+        { path: ":accountId", element: <NestedRoutesDetail /> },
+      ],
+    },
+  ],
+},
+```
+
+The layout component renders `<Outlet />` and each child fills in. This is the pattern for master-detail flows.
+
+## Programmatic navigation
+
+```tsx
+import { useNavigate } from "react-router";
+
+function CreateAccountForm() {
+  const navigate = useNavigate();
+  async function onSubmit(e: FormEvent) {
+    // ... create record ...
+    navigate(`/read-data/${newId}`);
+  }
+}
+```
+
+`useNavigate()` respects the router's `basename` — don't prepend `SFDC_ENV.basePath` yourself.
+
+## Common failures
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| 404 on hard refresh of a child route in Lightning | `ui-bundle.json` missing `fallback: "index.html"` | Add it and redeploy |
+| Navbar links resolve to `/lwr/application/ai/c-app/lwr/application/ai/c-app/read-data` | Manually prepending `SFDC_ENV.basePath` inside the app | Let `basename` handle it; use relative `to="read-data"` or `to="/read-data"` |
+| Routes work locally, break inside an Experience Cloud site | `basename` defaulted to `/` instead of picking up `SFDC_ENV.basePath` | Read `SFDC_ENV.basePath` at `createBrowserRouter` time |
+| `npm run build` fails with "no exported member BrowserRouter" | Importing from `react-router-dom` | Change the import to `react-router` |
+| `useParams()` returns `{}` | Route defined without `:paramName` | Match the path pattern to the param key |
+
+## What NOT to use
+
+- `react-router-dom` — deprecated in favor of v7's consolidated `react-router`
+- Hash routing (`createHashRouter`) — breaks Lightning Out deep-linking
+- A custom router layer on top of React Router — the platform already solves base-path and hard-refresh via `ui-bundle.json` + `basename`

--- a/skills/sf-multiframework/references/recipe-conventions.md
+++ b/skills/sf-multiframework/references/recipe-conventions.md
@@ -1,0 +1,245 @@
+# Recipe Conventions
+
+These conventions come from the [`trailheadapps/multiframework-recipes`](https://github.com/trailheadapps/multiframework-recipes) reference repo. They apply when building **learning recipes** — self-contained components that demonstrate one concept at the React × Salesforce intersection. They're a strong default for production code too, with explicit exceptions called out below.
+
+## What is a recipe?
+
+A self-contained component that demonstrates **one** concept. Each recipe should be understandable **in isolation, top to bottom, without opening another file**.
+
+## Goals & non-goals
+
+| Goal | Non-goal |
+|---|---|
+| Teach things React devs don't know about Salesforce | Teach React fundamentals |
+| Teach things Salesforce devs don't know about React | Re-document standard Hooks |
+| Show idiomatic Multi-Framework patterns | Be a complete production app |
+
+## File organization
+
+```
+src/
+  recipes/
+    <category>/
+      RecipeName.tsx       # the recipe itself
+  pages/
+    <Category>.tsx         # container that imports and renders recipes in a grid
+  components/
+    app/                   # app shell (Navbar, Layout, CodeBlock)
+    recipe/                # shared recipe UI (Skeleton, ContactTile, RecipeCard)
+    ui/                    # shadcn primitives
+```
+
+## Naming
+
+| Type | Convention | Example |
+|---|---|---|
+| Recipe file | PascalCase | `SingleRecord.tsx` |
+| `.graphql` file | camelCase | `singleAccountQuery.graphql` |
+| Hook | camelCase + `use` prefix | `useAuth.ts` |
+| Page (container) | PascalCase | `ReadData.tsx` |
+
+## Critical rule — recipe code ≠ production code
+
+Recipes optimize for **reading**, not authoring. The reader should hit the interesting code first.
+
+> **INLINE the thing the recipe teaches.** If a recipe is about GraphQL queries, the query MUST be visible in the recipe file. If it's about mutations, the mutation MUST be visible.
+
+> **DO NOT** abstract queries, mutations, types, or SDK calls into shared utility files and import them into recipes.
+
+This **overrides** the general "external `.graphql` + codegen" pattern. Recipes use **inline `gql`** instead.
+
+Exception: a later recipe in a category may reference a pattern taught earlier ("see SingleRecord for the basic query"), but the new code it adds must still be inline.
+
+## File structure (top to bottom — mandatory for recipes)
+
+```tsx
+/**
+ * Recipe 2.1: Single Record
+ *
+ * Queries a single Account by ID using sdk.graphql.
+ * Demonstrates the inline gql pattern and the { value } UIAPI shape.
+ */
+
+// 1. Imports
+import { useEffect, useState } from "react";
+import { createDataSDK, gql } from "@salesforce/sdk-data";
+
+// 2. GraphQL query (inline, not imported)
+const QUERY = gql`
+  query SingleAccount {
+    uiapi {
+      query {
+        Account(first: 1) {
+          edges {
+            node {
+              Id
+              Name { value }
+              Industry { value }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+// 3. Type definitions (explicit, not inferred)
+interface AccountFields {
+  id: string;
+  name: string;
+  industry: string | null;
+}
+
+// 4. Default export — the recipe component
+export default function SingleRecord() {
+  const [account, setAccount] = useState<AccountFields | undefined>();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const sdk = await createDataSDK();
+        const res = await sdk.graphql?.(QUERY);
+        const node = res?.data?.uiapi?.query?.Account?.edges?.[0]?.node;
+        if (node) {
+          setAccount({
+            id: node.Id,
+            name: node.Name.value ?? "—",
+            industry: node.Industry.value ?? null
+          });
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Request failed");
+      }
+    })();
+  }, []);
+
+  if (error) return <ErrorState message={error} />;
+  if (!account) return <Skeleton />;
+  return <AccountTile account={account} />;
+}
+
+// 5. Helper sub-components (below the main export)
+function Skeleton() { return <div className="slds-card slds-is-loading" />; }
+function ErrorState({ message }: { message: string }) {
+  return <div className="slds-text-color_error">{message}</div>;
+}
+function AccountTile({ account }: { account: AccountFields }) {
+  return (
+    <article className="slds-card">
+      <h2 className="slds-card__header-title">{account.name}</h2>
+      <p>{account.industry ?? "Unknown industry"}</p>
+    </article>
+  );
+}
+```
+
+## Component ordering: most relevant code first
+
+The default-exported component goes **at the top** of the file. Helpers go **below**. This is the opposite of typical "define before use" style, but better for a reading-first codebase.
+
+## Break complex JSX into named sub-components
+
+If you'd write a JSX comment like `{/* Column headers */}`, that's a sign it should be a named sub-component instead. Loading skeletons, error states, cards, and list items belong below the main component.
+
+Exception: recipes specifically *about* UI (`hello/`, `styling/`) can inline more.
+
+## Extract reused UI to `components/recipe/`
+
+If the same UI pattern appears across multiple **non-UI** recipes (skeletons, contact tiles, paginators, recipe cards, SLDS cards), extract it. Each recipe stays focused on its lesson.
+
+## Commenting
+
+| DO | DON'T |
+|---|---|
+| Comment platform-specific behavior: `{ value }` wrappers, `edges/node`, `__r` traversal, mutation input shapes | Comment standard React patterns (`useState`, `useEffect`, JSX) |
+| Explain why an SLDS class was chosen over Tailwind | Restate what the line of code does |
+| Cross-reference earlier recipes by name | Leave `console.log` or SDK debug code |
+
+## Anti-patterns (block in review)
+
+### ❌ Importing queries / mutations from `src/api/` into a recipe
+```tsx
+// BAD — hides the lesson
+import { getContacts } from "@/api/contacts";
+```
+
+### ❌ Complex inferred types
+```tsx
+// BAD — unreadable
+const [c, setC] = useState<Awaited<ReturnType<typeof getContacts>>[number]>();
+```
+Use explicit `interface` definitions.
+
+### ❌ Type casts for errors
+```tsx
+// BAD — silences the type system
+.catch(err => setError((err as Error).message))
+
+// GOOD — type-guards
+.catch(err => setError(err instanceof Error ? err.message : "Request failed"))
+```
+
+### ❌ Importing formatting utilities
+```tsx
+// BAD — opaque
+import { formatPhone } from "@/utils/formatPhone";
+<a href={`tel:${value}`}>{formatPhone(value)}</a>
+
+// GOOD — just render
+<a href={`tel:${phone}`}>{phone}</a>
+```
+
+### ❌ Mixing styling systems in one recipe
+```tsx
+// BAD
+<div className="flex items-center gap-4">           {/* Tailwind */}
+  <button className="slds-button slds-button_brand"> {/* SLDS */}
+```
+
+Pick one system per recipe. Data recipes typically use SLDS throughout.
+
+### ❌ Debug code committed in recipes
+```tsx
+// BAD
+createDataSDK().then(sdk => console.log(`sdk: ${JSON.stringify(sdk)}`));
+```
+
+### ❌ "Hello" recipes that teach pure React
+```tsx
+// BAD — works identically outside Salesforce
+export default function DataBinding() {
+  const [count, setCount] = useState(0);
+  return <p>Count: {count}</p>;
+}
+
+// GOOD — grounded in the platform
+export default function BindingAccountName() {
+  // Fetches an Account via GraphQL, binds Name.value to UI
+}
+```
+
+Every Hello recipe must involve the Salesforce platform. If it would work identically outside Salesforce, it belongs in a React tutorial, not here.
+
+## Verification checklist (per recipe)
+
+- [ ] Query / mutation is **inline** in the recipe file
+- [ ] Types are **explicit interfaces**, not `Awaited<ReturnType<...>>` or `NonNullable<...>` chains
+- [ ] Errors use `err instanceof Error`, not `(err as Error)`
+- [ ] No utility imports for formatting (e.g. `formatPhone`)
+- [ ] No `console.log` or SDK introspection debug code
+- [ ] One styling system used throughout the component
+- [ ] If it's a Hello recipe, it touches the Salesforce platform
+- [ ] `npm run build` passes
+- [ ] `npm run lint` passes
+
+## When to break the rules
+
+In **production application code** (not recipes), it's appropriate to:
+
+- extract shared queries to `src/api/utils/query/*.graphql` with codegen
+- abstract mutations into typed utility functions
+- centralize formatting helpers
+- use complex generic types where they genuinely add safety
+
+But never inside a file labeled as a recipe.

--- a/skills/sf-multiframework/references/scoring-rubric.md
+++ b/skills/sf-multiframework/references/scoring-rubric.md
@@ -1,0 +1,115 @@
+# Scoring Rubric
+
+Total: **100 points** across 6 categories. Use this to grade an app or PR.
+
+## Thresholds
+
+| Score | Meaning |
+|---|---|
+| 90+ | Deploy with confidence |
+| 75–89 | Good — review warnings before deploying |
+| 60–74 | Needs focused revision |
+| < 60 | Block deploy |
+
+---
+
+## Project Structure (20 points)
+
+| Item | Points | What earns full credit |
+|---|---|---|
+| Bundle lives at `uiBundles/<appName>/` | 3 | Correct path, name matches metadata |
+| `<appName>.uibundle-meta.xml` present and valid | 3 | `<isActive>`, `<masterLabel>`, `<target>`, `<version>` all set |
+| `ui-bundle.json` present and valid | 3 | Required `outputDir`, matches build emit dir |
+| `apiVersion` matches target org | 2 | e.g. `v66.0` aligned with `sfdx-project.json` |
+| Two distinct `package.json` files (root + bundle) | 2 | No accidental merge or duplicate dep declarations |
+| Path aliases configured in **both** `vite.config.ts` and `tsconfig.json` | 2 | Aliases match between the two |
+| External app: `digitalExperiences/sfdc_cms_site/content.json` correct | 3 | `appContainer: true`, valid `appSpace` |
+| Build artifacts under `outputDir` count < 2,500 | 2 | Source maps disabled or filtered for production |
+
+## Routing & Hosting (15 points)
+
+| Item | Points | What earns full credit |
+|---|---|---|
+| SPA fallback set | 4 | `routing.fallback: "index.html"` |
+| `trailingSlash` chosen and consistent | 2 | `never` / `always` / `auto` — matches in-app router |
+| `target` matches deployment intent | 4 | `AppLauncher` for internal, `Experience` for external; companion metadata present for external |
+| Rewrites / redirects (if any) are sane | 2 | Status codes correct; no redirect loops |
+| Hard refresh on a deep route works | 3 | Manual smoke-test |
+
+## Data Access (25 points)
+
+| Item | Points | What earns full credit |
+|---|---|---|
+| Uses `@salesforce/sdk-data` exclusively for Salesforce calls | 5 | No raw `fetch` / `axios` to Salesforce endpoints |
+| Optional chaining on SDK methods | 2 | `sdk.graphql?.()`, `sdk.fetch?.()` |
+| GraphQL preferred over REST where possible | 3 | UI API GraphQL for record reads/writes |
+| `{ value }` field shape respected | 3 | Fields read as `record.X.value` |
+| `edges/node` connection pattern handled | 2 | `result.uiapi.query.X.edges?.map(e => e?.node)` |
+| `schema.graphql` regenerated from connected org | 2 | `npm run graphql:schema` is committed in workflow |
+| Codegen scalar mappings complete | 2 | UIAPI scalars mapped in `codegen.yml` |
+| Error strategy chosen per call site | 4 | Strict / Tolerant / Permissive picked deliberately |
+| 401 / 403 callbacks wired (Experience apps) | 2 | `on401` / `on403` registered in `createDataSDK` |
+
+## Styling Discipline (10 points)
+
+| Item | Points | What earns full credit |
+|---|---|---|
+| One styling system per component | 3 | No SLDS + Tailwind mixed inside one component |
+| App-shell vs recipe styling boundary respected | 2 | Tailwind / shadcn for shell; SLDS or chosen system for data recipes |
+| SLDS imports happen once globally | 1 | Single import in `global.css` (or equivalent) |
+| Focus ring color is Salesforce blue if SLDS-feel desired | 1 | `--ring: #0176d3` for shadcn projects targeting native feel |
+| `IconSettings` wraps `design-system-react` usage | 1 | Icons resolve correctly |
+| Dark-mode tokens defined when supported | 1 | `.dark` overrides in `global.css` |
+| No mixed SLDS versions | 1 | Don't combine `design-system-react` and `@salesforce-ux/design-system` |
+
+## ACC Integration (15 points — only scored if ACC is in scope)
+
+| Item | Points | What earns full credit |
+|---|---|---|
+| Agentforce preference enabled in target org | 2 | Setup confirms |
+| Employee Agent with topics + actions exists | 2 | Required to render |
+| My Domain cookie policy: first-party requirement OFF | 2 | Setup confirms |
+| Trusted Domains for Inline Frames includes prod + dev | 3 | Both, with iFrame type Lightning Out |
+| `@salesforce/agentforce-conversation-client` installed | 1 | Pinned in `package.json` |
+| Mount uses `useRef` + `useEffect` with cleanup | 3 | `widgetRef.current?.destroy()` in cleanup |
+| Display mode chosen deliberately | 2 | Floating / Docked / Inline matches UX intent |
+
+> If ACC is not in scope, redistribute these 15 points: +10 to Data Access, +5 to Project Structure.
+
+## Deployment Readiness (15 points)
+
+| Item | Points | What earns full credit |
+|---|---|---|
+| `npm run lint` passes | 2 | Clean lint output |
+| `npm run build` passes | 3 | Clean build, type-check passes |
+| `dist/` size within budget | 2 | Under 2,500 files |
+| Deploy via MCP first, CLI as fallback | 2 | Workflow uses `mcp_Salesforce_DX_deploy_metadata` when available |
+| External app: all four metadata folders deployed together | 2 | `digitalExperienceConfigs/`, `digitalExperiences/`, `networks/`, `sites/` |
+| Permission set assigned to running user | 1 | App is reachable for the test user |
+| Sample data plan available if applicable | 1 | `sf data import tree --plan ...` works |
+| Smoke-test pass: App Launcher / Digital Experiences | 1 | App appears and renders |
+| Smoke-test pass: hard-refresh deep route | 1 | No 404 |
+
+---
+
+## Quick scoring template
+
+```
+Project Structure       : __ / 20
+Routing & Hosting       : __ / 15
+Data Access             : __ / 25
+Styling Discipline      : __ / 10
+ACC Integration         : __ / 15  (or N/A — redistribute)
+Deployment Readiness    : __ / 15
+                          --------
+Total                   : __ / 100
+```
+
+## What disqualifies an app regardless of score
+
+- Raw `fetch` / `axios` to Salesforce endpoints
+- Multi-Framework enabled in a non-sandbox/scratch org with production data
+- ACC integration without My Domain cookie policy + Trusted Domains both configured
+- External app deployed without companion `digitalExperiences` / `networks` / `sites`
+- Lightning base components (`lightning-card`, etc.) imported from a React UI bundle (won't work)
+- `@wire` decorators inside the React app (not supported)

--- a/skills/sf-multiframework/references/scoring-rubric.md
+++ b/skills/sf-multiframework/references/scoring-rubric.md
@@ -20,7 +20,7 @@ Total: **100 points** across 6 categories. Use this to grade an app or PR.
 | Bundle lives at `uiBundles/<appName>/` | 3 | Correct path, name matches metadata |
 | `<appName>.uibundle-meta.xml` present and valid | 3 | `<isActive>`, `<masterLabel>`, `<target>`, `<version>` all set |
 | `ui-bundle.json` present and valid | 3 | Required `outputDir`, matches build emit dir |
-| `apiVersion` matches target org | 2 | e.g. `v66.0` aligned with `sfdx-project.json` |
+| API version managed at project/deploy layer | 2 | `sfdx-project.json` matches target org; no unsupported `apiVersion` in `ui-bundle.json` |
 | Two distinct `package.json` files (root + bundle) | 2 | No accidental merge or duplicate dep declarations |
 | Path aliases configured in **both** `vite.config.ts` and `tsconfig.json` | 2 | Aliases match between the two |
 | External app: `digitalExperiences/sfdc_cms_site/content.json` correct | 3 | `appContainer: true`, valid `appSpace` |

--- a/skills/sf-multiframework/references/setup.md
+++ b/skills/sf-multiframework/references/setup.md
@@ -1,0 +1,122 @@
+# Configure Your Org for React Development
+
+> Beta availability: **sandbox and scratch orgs only**. Default language must be `en_US`. Developer Edition orgs and Trailhead Playgrounds are not supported.
+
+## 1. Pre-flight
+
+- Latest **Salesforce CLI**: `sf update`
+- Latest **Salesforce Extension Pack** for VS Code (or equivalent IDE)
+- **Node.js v22+** and **npm**
+- For external apps: planned **Customer Community / Customer Community Plus** (B2C) or **Partner Community / Channel Account** (B2B) user licenses
+
+## 2. Enable Multi-Framework (Beta)
+
+> Required permission: **Customize Application**.
+
+1. Setup → search **"Salesforce Multi-Framework"** → click **React Development with Salesforce Multi-Framework (Beta)**.
+2. Click **Enable Beta** → confirm.
+3. **Cannot be disabled** afterwards. Treat the toggle as one-way.
+
+## 3. Authorize the org
+
+```bash
+# Sandbox or production hub
+sf org login web -d -a myhuborg
+
+# Sandbox-specific (skip -d)
+sf org login web -a mysandbox
+
+# Optional: scratch org from project def
+sf org create scratch -d -f config/project-scratch-def.json -a recipes
+```
+
+For scratch orgs, **explicitly set `"language": "en_US"`** in the project def. Non-English orgs hit known issues.
+
+## 4. Install the UI Bundle CLI plugin
+
+```bash
+sf plugins install @salesforce/plugin-ui-bundle-dev
+```
+
+This adds the `sf template generate ui-bundle` command and runtime helpers used by `npm run dev`.
+
+## 5. (External apps only) Set up Digital Experiences
+
+External React apps live inside an Experience Cloud site even though you don't author the site in Experience Builder.
+
+1. Setup → confirm **Digital Experiences** is enabled.
+2. Setup → Digital Experiences → All Sites → **New** (any template — you'll back out).
+3. Click **Back to Setup** without picking a template — this just ensures the underlying dependencies exist.
+4. Confirm Customer/Partner Community user licenses are available.
+
+The metadata you ship later (`digitalExperienceConfigs`, `digitalExperiences/sfdc_cms_site`, `networks`, `sites`) wires the React app to the site.
+
+## 6. (Agentforce Vibes users only) MCP server setup
+
+If you'll use Agentforce Vibes' natural-language scaffolding:
+
+1. Setup → MCP Servers → **metadata-experts** → **Activate**.
+2. Setup → MCP Servers → **salesforce-api-context** → **Activate**.
+3. In VS Code, open the Agentforce Vibes panel.
+4. Connect to your authorized org.
+5. Confirm these MCP servers are enabled and connected:
+   - Salesforce DX MCP server
+   - Salesforce Metadata Experts MCP server
+   - Salesforce API Context MCP server
+6. Confirm all Salesforce skills and rules are enabled in the Vibes panel.
+
+If you're going to vibe-code CMS content into the app, also activate the **content-readonly** MCP server (DE / scratch only):
+
+1. Setup → CMS → toggle **Access the Content Read-Only MCP Server and Tools (Beta)**.
+2. Setup → MCP Servers → **content-readonly** → **Activate**.
+3. Add `content-readonly` as a remote server in Vibes pointing at the Server URL from the MCP detail page.
+4. Set `cmsAssetProviderOrg` to the alias of the org that holds your CMS content.
+
+For `search_electronic_media`: deploy the **CMS Base (Beta)** data kit, then create a Hybrid Search index in Data Cloud over the `Electronic Media` source object with `Description` chunked via Passage Extraction.
+
+## 7. (ACC users only) Org configuration
+
+To embed the Agentforce Conversation Client in a React app:
+
+### 7a. Enable Agentforce
+Setup → Einstein → Einstein Generative AI → Agentforce Studio → Agentforce Agents → enable **Agentforce** preference. Configure at least one Employee Agent with topics + actions.
+
+### 7b. Cookie policy
+Setup → My Domain → Routing and Policies → **uncheck** *Require first-party use of Salesforce cookies* → **Save**.
+
+This is required because the React app is on a non-Salesforce origin (including `localhost`) and the ACC iframe must persist session state across origins.
+
+### 7c. Trusted Domains for Inline Frames
+Setup → Session Settings → **Trusted Domains for Inline Frames** → **Add Domain**:
+
+- Production / preview origin (e.g. `https://app.example.com`)
+- Local dev origin (e.g. `http://localhost:5173`)
+
+Set **iFrame type** to **Lightning Out** for each.
+
+## 8. Optional — Permission Set
+
+Most starter projects ship a `recipes` permission set granting access to the bundle and any custom objects. Assign it to the running user:
+
+```bash
+sf org assign permset -n recipes
+```
+
+## 9. Smoke-test the setup
+
+```bash
+sf org open
+```
+
+Expected: org opens, App Launcher contains your app (after deploy), or Digital Experiences shows the linked site (external apps).
+
+## Common setup failures
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Beta toggle missing in Setup | DE org or Playground | Use a sandbox or scratch org |
+| Beta toggle visible but not clickable | User lacks **Customize Application** | Assign the System Admin profile or equivalent |
+| `sf template generate ui-bundle` not recognized | `@salesforce/plugin-ui-bundle-dev` not installed | `sf plugins install @salesforce/plugin-ui-bundle-dev` |
+| Vite dev server starts but data calls 401 | Org not authorized in current shell | `sf org login web -a <alias>` |
+| ACC FAB never appears | Trusted Domains not added or cookies still restricted | Re-check steps 7b and 7c |
+| Non-English org blocks app loading | Known issue | Set org language to `en_US` (scratch) or use a different org |

--- a/skills/sf-multiframework/references/styling.md
+++ b/skills/sf-multiframework/references/styling.md
@@ -1,0 +1,224 @@
+# Styling React Apps
+
+React UI bundles **don't have access to Lightning base components or `lightning/*` modules**, so the automatic SLDS styling LWCs get isn't available. You have three viable approaches; pick one **per component** (mixing inside one component is the most common review failure).
+
+## The three approaches
+
+| Approach | When to choose | Pros | Cons |
+|---|---|---|---|
+| **SLDS blueprints (CSS classes)** | You want native Salesforce look, full markup control | Pixel-accurate Lightning feel; latest SLDS available | You manage every CSS class manually; no auto-updates |
+| **`@salesforce/design-system-react`** | You want SLDS components without writing the markup | Pre-built React components; familiar Lightning API | Pins an older SLDS CSS version |
+| **Tailwind + shadcn/ui** | You want a custom-branded look or fresh design system | Fast to compose; great DX; modern aesthetic | Drifts from native SLDS unless you tokenize carefully |
+
+## 1. SLDS Blueprints
+
+Apply the SLDS class names directly in JSX. Import the SLDS CSS once globally.
+
+```bash
+npm install @salesforce-ux/design-system
+```
+
+```css
+/* src/styles/slds.css */
+@import "@salesforce-ux/design-system/assets/styles/salesforce-lightning-design-system.css";
+```
+
+```tsx
+function AccountCard() {
+  return (
+    <article className="slds-card">
+      <div className="slds-card__header slds-grid">
+        <header className="slds-media slds-media_center slds-has-flexi-truncate">
+          <div className="slds-media__body">
+            <h2 className="slds-card__header-title">
+              <span>Account</span>
+            </h2>
+          </div>
+        </header>
+      </div>
+      <div className="slds-card__body slds-card__body_inner">
+        Acme Corp
+      </div>
+      <footer className="slds-card__footer">
+        <button className="slds-button slds-button_brand">View</button>
+      </footer>
+    </article>
+  );
+}
+```
+
+> Blueprint = HTML + CSS class contract. You own the markup; SLDS owns the look. There is **no behavior** — you wire interaction yourself.
+
+## 2. `@salesforce/design-system-react`
+
+Pre-built React components matching SLDS.
+
+```bash
+npm install @salesforce/design-system-react
+```
+
+Wrap with `IconSettings` to configure the sprite path so icons resolve:
+
+```tsx
+import IconSettings from "@salesforce/design-system-react/components/icon-settings";
+import Card from "@salesforce/design-system-react/components/card";
+import Button from "@salesforce/design-system-react/components/button";
+
+export default function App() {
+  return (
+    <IconSettings iconPath="/assets/icons">
+      <Card heading="Acme Corp">
+        <Button variant="brand" label="View" />
+      </Card>
+    </IconSettings>
+  );
+}
+```
+
+Caveat: this package pins an older SLDS CSS — newer SLDS tokens / blueprints may not match. Don't combine with `@salesforce-ux/design-system` in the same component (versions can clash).
+
+## 3. Tailwind + shadcn/ui
+
+The pattern used by `multiframework-recipes` for the **app shell** (Navbar, Layout, Card primitives). shadcn copies component source into your project so you customize via Tailwind classes directly.
+
+```bash
+# Tailwind 4 + shadcn (see official shadcn docs for full init)
+npx shadcn@latest init
+npx shadcn@latest add button card input
+```
+
+`global.css` is your design-system entry point:
+
+```css
+@import "tailwindcss";
+
+@layer base {
+  body {
+    @apply min-h-screen antialiased text-foreground bg-background;
+  }
+}
+
+:root {
+  --color-background: oklch(1 0 0);
+  --color-foreground: oklch(0.145 0 0);
+  --color-primary:    oklch(0.205 0 0);
+  --color-secondary:  oklch(0.97 0 0);
+  --color-border:     oklch(0.922 0 0);
+  --radius:           0.5rem;
+  --ring:             #0176d3;          /* Salesforce brand blue for native focus feel */
+}
+
+.dark {
+  --color-background: oklch(0.145 0 0);
+  --color-foreground: oklch(0.985 0 0);
+}
+
+@theme inline {
+  --color-background: var(--color-background);
+  --color-foreground: var(--color-foreground);
+  --color-primary:    var(--color-primary);
+  --color-secondary:  var(--color-secondary);
+  --color-border:     var(--color-border);
+}
+```
+
+Now utilities like `bg-background`, `text-foreground`, `border-border`, `ring-ring` work across components.
+
+### Notable token differences vs SLDS
+
+| Token | SLDS 1 | SLDS 2 | shadcn default |
+|---|---|---|---|
+| Border radius (button/card) | `0.25rem` (4px) | `15rem` (pill) | `0.5rem` |
+| Focus ring color | Salesforce blue (`#0176d3`) | Same | Black/grey |
+| Secondary background | Light grey (`#f3f3f3`) | Same | Darker grey |
+
+If you want a Salesforce-native feel with shadcn, override these tokens in `global.css` rather than per-component.
+
+## Migration: `lightning-card` → shadcn `Card`
+
+This is the canonical example because it shows **template-driven (LWC slots)** vs **composition-driven (React)**.
+
+### Original LWC
+
+```html
+<lightning-card title="Account" icon-name="standard:account">
+  <p slot="actions">Edit</p>
+  <p>Acme Corp</p>
+  <p slot="footer">Updated 2 days ago</p>
+</lightning-card>
+```
+
+### React with shadcn
+
+```tsx
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter
+} from "@/components/ui/card";
+
+export function AccountCard() {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>Account</CardTitle>
+        <button className="text-sm">Edit</button>
+      </CardHeader>
+      <CardContent>Acme Corp</CardContent>
+      <CardFooter className="text-xs text-muted-foreground">
+        Updated 2 days ago
+      </CardFooter>
+    </Card>
+  );
+}
+```
+
+Each named slot becomes an explicit sub-component. You see the structure top-to-bottom in JSX.
+
+## Icons
+
+| Source | Pattern |
+|---|---|
+| SLDS sprite (CSS) | `<svg className="slds-icon slds-icon_x-small"><use xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#event" /></svg>` |
+| `design-system-react` | Wrap in `<IconSettings iconPath="/assets/icons">`, then `<Icon category="utility" name="event" />` |
+| Tailwind / shadcn | Use `lucide-react` (`<Calendar />`) or your preferred icon set |
+
+> Workspace rule (.cursorrules): prefer `utility:` icons over `standard:` for transparent backgrounds. Same applies in React app icon picks.
+
+## One styling system per component
+
+The single most common review failure is mixing systems inside one component:
+
+```tsx
+// ❌ Mixing — hostile to readers and to dark mode
+<div className="flex items-center gap-4">          {/* Tailwind */}
+  <button className="slds-button slds-button_brand"> {/* SLDS */}
+    Save
+  </button>
+</div>
+
+// ✅ Pick one
+<div className="slds-grid slds-grid_vertical-align-center slds-gutters">
+  <button className="slds-button slds-button_brand">Save</button>
+</div>
+
+// ✅ Or commit to Tailwind
+<div className="flex items-center gap-4">
+  <Button variant="default">Save</Button>
+</div>
+```
+
+It's fine to use **Tailwind for the app shell** and **SLDS inside data recipes**, as long as the boundary is the component itself.
+
+## Dark mode
+
+- Tailwind/shadcn: define `.dark` overrides in `global.css`; toggle by adding `class="dark"` on `<html>`.
+- SLDS blueprints: SLDS 2 has dark theming variables. SLDS 1 does not — you'd build dark overrides yourself.
+- `design-system-react`: limited; the pinned SLDS version may not support modern dark theming.
+
+## Reference
+
+The **styling** examples in the [Multi-Framework Recipes](https://github.com/trailheadapps/multiframework-recipes) repo demonstrate all three approaches side-by-side, including the exact `global.css` token setup and a fully migrated `Card` example.

--- a/skills/sf-multiframework/references/templates.md
+++ b/skills/sf-multiframework/references/templates.md
@@ -1,0 +1,124 @@
+# Templates: `reactinternalapp` vs `reactexternalapp`
+
+The `sf template generate ui-bundle` command supports two React templates that pre-wire common patterns. Choose based on your **audience and authentication model**.
+
+## `reactinternalapp` — internal employee apps
+
+**Audience:** employees signing in with Salesforce credentials.
+**Target:** `AppLauncher`.
+**Includes:**
+
+- Pre-wired Vite + TypeScript + Tailwind + shadcn/ui shell
+- Object search using GraphQL UI API
+- **Agentforce Conversation Client** integration (assumes ACC org config is complete)
+- Recommended folder structure (`recipes/`, `pages/`, `components/`)
+
+When to pick it:
+- Single-page employee app inside Salesforce.
+- Users are already authenticated.
+- You plan to embed an Employee Agent.
+
+```bash
+sf template generate ui-bundle --name myEmployeeApp --template reactinternalapp
+```
+
+## `reactexternalapp` — external B2B / B2C portals
+
+**Audience:** customers or partners signing in from outside the org.
+**Target:** `Experience`.
+**Includes:**
+
+- Everything `reactinternalapp` provides, **plus**:
+- A pre-wired **Experience Cloud site** with multiple pages
+- Authentication entry points
+- Object search
+
+To use this template you also need:
+
+- Digital Experiences enabled in the org
+- Customer/Partner Community user licenses
+
+```bash
+sf template generate ui-bundle --name myPortal --template reactexternalapp
+
+# Or scaffold a brand-new DX project + external app:
+sf template generate project --template reactexternalapp
+```
+
+### Required companion metadata for external apps
+
+External apps **cannot ship as just a `UIBundle`**. You must also deploy:
+
+```
+force-app/main/default/
+  digitalExperienceConfigs/         # Workspace settings (label, URL prefix, type)
+  digitalExperiences/
+    sfdc_cms_site/
+      content.json                  # MUST set appContainer + appSpace
+  networks/                         # The Experience Cloud site
+  sites/                            # Salesforce site config
+  uiBundles/myPortal/
+```
+
+#### `digitalExperiences/sfdc_cms_site/content.json` — the critical wiring
+
+```json
+{
+  "appContainer": true,
+  "appSpace": "c__myPortal"
+}
+```
+
+| Property | Rule |
+|---|---|
+| `appContainer` | **Must be `true`** to flag the site as a React app container |
+| `appSpace` | **Must be `<NamespacePrefix>__<DeveloperName>`** — use `c__<DeveloperName>` if the org has no namespace |
+
+> Unlike a standard LWR site, the React app's `digitalExperiences/` folder contains **only** `sfdc_cms_site/`. Do not try to author additional CMS content directories.
+
+> The site **cannot be edited in Experience Builder**. Its only role is to host the React bundle.
+
+## Picking the right target after the fact
+
+Switching `<target>` from `AppLauncher` to `Experience` (or vice versa) is **not a hot swap**. You'll need:
+
+- Going internal → external: add the four metadata folders above and a real Experience Cloud site, then redeploy.
+- Going external → internal: remove the dependent site metadata or it will reference a non-existent app target.
+
+Plan the target up front whenever possible.
+
+## Manual setup (no template)
+
+If you're not using a template and writing the bundle by hand, install these helpers:
+
+```bash
+npm install --save-dev @salesforce/vite-plugin-ui-bundle
+npm install @salesforce/ui-bundle @salesforce/sdk-data
+```
+
+Minimum `vite.config.ts`:
+
+```ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { uiBundle } from "@salesforce/vite-plugin-ui-bundle";
+
+export default defineConfig({
+  plugins: [react(), uiBundle()],
+  build: { outDir: "dist", sourcemap: false }
+});
+```
+
+Minimum `package.json` scripts:
+
+```json
+{
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  }
+}
+```
+
+Add a starter `ui-bundle.json` (see [project-structure.md](project-structure.md)) and `<app>.uibundle-meta.xml`, and you have a deployable bundle.

--- a/skills/sf-multiframework/references/templates.md
+++ b/skills/sf-multiframework/references/templates.md
@@ -115,7 +115,7 @@ Minimum `package.json` scripts:
 {
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc --noEmit && vite build",
     "preview": "vite preview"
   }
 }

--- a/skills/sf-multiframework/references/testing.md
+++ b/skills/sf-multiframework/references/testing.md
@@ -1,0 +1,301 @@
+# Testing UI Bundles
+
+The reference repo ships a **Vitest + React Testing Library + Playwright** stack with an 85% coverage threshold and per-recipe accessibility tests (`vitest-axe`). Treat this as the default.
+
+| Layer | Tool | Purpose |
+|---|---|---|
+| Unit / component | **Vitest** + **@testing-library/react** | Render recipe components with mocked SDK, assert on DOM |
+| Accessibility | **vitest-axe** | Runs axe-core against the rendered container |
+| End-to-end | **Playwright** | Runs the built `dist/` against a static server; no live org required |
+| Org-side Apex | **sf-testing** skill | Apex test runner — this is *not* this stack's job |
+
+## Install
+
+```bash
+npm install --save-dev vitest @vitest/ui @vitest/coverage-v8 \
+  @testing-library/react @testing-library/jest-dom @testing-library/user-event @testing-library/dom \
+  vitest-axe jsdom \
+  @playwright/test serve
+```
+
+## `package.json` scripts
+
+```json
+{
+  "scripts": {
+    "test": "vitest",
+    "test:coverage": "vitest --run --coverage",
+    "test:e2e": "playwright test",
+    "build:e2e": "npm run build && node scripts/rewrite-e2e-assets.mjs"
+  }
+}
+```
+
+`npm run test` is watch mode; `test -- --run` is CI mode. `test:coverage` emits text + HTML + lcov.
+
+## `vitest.config.ts`
+
+```ts
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      "@api": path.resolve(__dirname, "./src/api"),
+      "@components": path.resolve(__dirname, "./src/components"),
+    },
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: "./vitest.setup.ts",
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+      thresholds: {
+        global: { branches: 85, functions: 85, lines: 85, statements: 85 },
+      },
+    },
+  },
+});
+```
+
+### `vitest.setup.ts`
+
+Two jsdom-specific stubs matter for axe-core:
+
+```ts
+import "@testing-library/jest-dom/vitest";
+import * as matchers from "vitest-axe/matchers";
+import { expect } from "vitest";
+
+expect.extend(matchers);
+
+// axe-core's color-contrast rule reaches into canvas + computed styles for
+// pseudo-elements. jsdom implements neither — stub so axe doesn't throw.
+HTMLCanvasElement.prototype.getContext = (() => null) as any;
+
+const origGetComputedStyle = window.getComputedStyle;
+window.getComputedStyle = (el, pseudoEl) =>
+  pseudoEl ? ({} as CSSStyleDeclaration) : origGetComputedStyle(el);
+```
+
+Without these, every axe assertion throws `TypeError: getContext is not a function`.
+
+## The standard recipe test pattern
+
+Each recipe gets a `<Name>.test.tsx` sibling file. Mock `@salesforce/sdk-data` globally, control `graphql` / `fetch` per test, assert on DOM:
+
+```tsx
+// src/recipes/hello/BindingAccountName.test.tsx
+import { render, screen } from "@testing-library/react";
+import type { Mock } from "vitest";
+import { createDataSDK } from "@salesforce/sdk-data";
+import { axe } from "vitest-axe";
+import BindingAccountName from "./BindingAccountName";
+
+vi.mock("@salesforce/sdk-data", () => ({
+  createDataSDK: vi.fn(),
+  gql: (strings: TemplateStringsArray) => strings.join(""),
+}));
+
+const SUCCESS = {
+  data: {
+    uiapi: {
+      query: {
+        Account: {
+          edges: [{ node: { Id: "001", Name: { value: "Acme Corp" } } }],
+        },
+      },
+    },
+  },
+  errors: [],
+};
+
+describe("BindingAccountName", () => {
+  const mockGraphql = vi.fn();
+
+  beforeEach(() => {
+    (createDataSDK as Mock).mockResolvedValue({ graphql: mockGraphql });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the account name after data loads", async () => {
+    mockGraphql.mockResolvedValue(SUCCESS);
+    render(<BindingAccountName />);
+    expect(await screen.findByText("Acme Corp")).toBeInTheDocument();
+  });
+
+  it("renders error state on rejected promise", async () => {
+    mockGraphql.mockRejectedValue(new Error("Network down"));
+    render(<BindingAccountName />);
+    expect(await screen.findByText(/network down/i)).toBeInTheDocument();
+  });
+
+  it("is accessible", async () => {
+    mockGraphql.mockResolvedValue(SUCCESS);
+    const { container } = render(<BindingAccountName />);
+    await screen.findByText("Acme Corp");
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+```
+
+### LWC → React test-pattern translation
+
+| LWC Jest | React equivalent |
+|---|---|
+| `registerApexTestWireAdapter` / `registerLdsTestWireAdapter` | `vi.mock('@salesforce/sdk-data', () => ...)` with a `vi.fn()` graphql |
+| `adapter.emit(data); await Promise.resolve()` | `mockGraphql.mockResolvedValue(data)` + `await screen.findByText(...)` |
+| `el.shadowRoot.querySelector(...)` | `screen.getByRole(...)` / `screen.getByText(...)` / `container.querySelector(...)` |
+| `flushPromises()` | `findBy*` queries poll automatically; or `await waitFor(() => ...)` |
+| `@salesforce/sfdx-lwc-jest` | Vitest + React Testing Library |
+
+### Mock patterns by scenario
+
+| Scenario | Mock shape |
+|---|---|
+| Query success | `mockGraphql.mockResolvedValue({ data: {...}, errors: [] })` |
+| Query with errors | `mockGraphql.mockResolvedValue({ data: null, errors: [{ message: "..." }] })` |
+| Network / transport failure | `mockGraphql.mockRejectedValue(new Error("..."))` |
+| REST via `sdk.fetch` | `mockResolvedValue({ graphql: ..., fetch: vi.fn().mockResolvedValue({ ok: true, json: async () => ... }) })` |
+| Mutation then query sequence | `mockGraphql.mockResolvedValueOnce(mutationRes).mockResolvedValueOnce(queryRes)` |
+
+## Accessibility testing
+
+Every recipe ends with an axe check:
+
+```tsx
+it("is accessible", async () => {
+  const { container } = render(<Component />);
+  await screen.findByText(/something/);   // wait for async render
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});
+```
+
+This is non-negotiable in the reference repo and catches SLDS markup mistakes (missing `aria-label`, `role="status"` vs `role="alert"`, incorrect heading hierarchy). If SLDS React components break color-contrast, use axe's `rules` override per test — don't disable axe globally.
+
+## `router` tests
+
+Wrap the component under test in `MemoryRouter` with the route you want to test:
+
+```tsx
+import { MemoryRouter, Routes, Route } from "react-router";
+
+render(
+  <MemoryRouter initialEntries={["/route-parameters/001ABC"]}>
+    <Routes>
+      <Route path="/route-parameters/:accountId" element={<RouteParametersDetail />} />
+    </Routes>
+  </MemoryRouter>
+);
+```
+
+`useParams()` resolves from the matched route; don't try to mock it.
+
+## End-to-end with Playwright
+
+The reference repo runs e2e against the built `dist/` via `serve`, not `vite preview`. `vite preview` invokes the Salesforce plugin which can fail without a connected org; a static server doesn't.
+
+### `playwright.config.ts`
+
+```ts
+import { defineConfig, devices } from "@playwright/test";
+
+const E2E_PORT = 5175;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: `http://localhost:${E2E_PORT}`,
+    trace: "on-first-retry",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "Mobile Chrome", use: { ...devices["Pixel 5"] } },
+  ],
+  webServer: {
+    command: `npx serve dist -l ${E2E_PORT}`,
+    url: `http://localhost:${E2E_PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: process.env.CI ? 120_000 : 60_000,
+  },
+});
+```
+
+### What e2e tests *can't* do
+
+- No real org data — the built bundle includes no `schema.graphql` at runtime.
+- No ACC — the Lightning Out widget won't render outside a Salesforce host.
+- No cookies / session — `createDataSDK()` will fail or return capability-missing.
+
+Write e2e for: routing, layout regressions, empty-state rendering, keyboard navigation, focus management. Leave data-dependent flows to unit tests with mocked SDK.
+
+## Coverage thresholds
+
+The reference repo sets `branches/functions/lines/statements: 85`. Enforce this in CI (`vitest --run --coverage`). The config's `exclude` block matters:
+
+```ts
+coverage: {
+  exclude: [
+    "node_modules/",
+    "src/**/*.d.ts",
+    "src/main.tsx",
+    "src/vite-env.d.ts",
+    "src/components/**/index.ts",    // barrel files
+    "**/*.config.ts",
+    "build/",
+    "dist/",
+    "coverage/",
+    "eslint.config.js",
+  ],
+},
+```
+
+## CI wiring
+
+```yaml
+# .github/workflows/ci.yml (excerpt)
+- name: "Install React app dependencies"
+  run: npm ci --prefix force-app/main/.../uiBundles/myApp
+
+- name: "Lint"
+  run: npm run lint --prefix force-app/main/.../uiBundles/myApp
+
+- name: "Test"
+  run: npm run test --prefix force-app/main/.../uiBundles/myApp -- --run --coverage
+
+- name: "Build"
+  run: npm run build --prefix force-app/main/.../uiBundles/myApp
+
+- name: "Playwright"
+  run: npm run test:e2e --prefix force-app/main/.../uiBundles/myApp
+```
+
+Full CI sequence: [ci-deploy.md](ci-deploy.md).
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `TypeError: getContext is not a function` in axe tests | Missing `HTMLCanvasElement` stub in `vitest.setup.ts` |
+| `Cannot find module '@salesforce/sdk-data'` in tests | Vitest needs a `vi.mock(...)` hoist; verify it's at the top of the file |
+| `findBy*` queries time out but UI clearly renders | Check whether the mocked `graphql` actually resolves — missing `.mockResolvedValue(...)` returns `undefined` |
+| Playwright webServer times out in CI | Increase `timeout` to 120s; confirm `dist/` exists before `webServer` runs |
+| Coverage report shows 0% for route pages | `src/pages` is glob-included but the pages just forward to recipes; test the recipes directly or exclude `src/pages` |

--- a/skills/sf-multiframework/references/troubleshooting.md
+++ b/skills/sf-multiframework/references/troubleshooting.md
@@ -10,7 +10,7 @@ Bucketed by where the failure happens. Each row is a real failure mode seen in M
 | Beta toggle visible but greyed out | User missing **Customize Application** | Assign System Administrator profile or equivalent permission |
 | App loads in English only / blank screens elsewhere | Org default language ≠ `en_US` | Scratch: set `"language": "en_US"`. Sandbox: change org language |
 | `sf template generate ui-bundle` not recognized | `@salesforce/plugin-ui-bundle-dev` not installed | `sf plugins install @salesforce/plugin-ui-bundle-dev` |
-| `npm install` fails with peer warnings on React 19 | Older deps in template | Upgrade to template's pinned versions, then `npm install` again |
+| `npm install` fails with Vite peer conflict | Salesforce Vite plugin and latest `@vitejs/plugin-react` target different Vite majors | Pin compatible majors, e.g. Vite 7 + `@vitejs/plugin-react` 5 |
 
 ## Project & build
 
@@ -19,6 +19,10 @@ Bucketed by where the failure happens. Each row is a real failure mode seen in M
 | Build succeeds, deploy fails | `outputDir` in `ui-bundle.json` doesn't match Vite `build.outDir` | Align both to `dist` |
 | Deploy fails with file-count error | UIBundle exceeded 2,500 files | Disable source maps in production; prune `dist/` |
 | Deploy succeeds but app missing from App Launcher | `<isActive>false</isActive>` or wrong `<target>` | Set `isActive: true`; confirm target is `AppLauncher` |
+| Deploy fails: `ui-bundle.json contains unknown property: 'apiVersion'` | Current validator only allows `outputDir`, `routing`, `headers` | Remove `apiVersion` from `ui-bundle.json`; rely on `sfdx-project.json` / deploy API version |
+| Deploy fails: `apiVersion invalid at this location in type UIBundle` | `.uibundle-meta.xml` includes unsupported `<apiVersion>` | Remove `<apiVersion>` from `.uibundle-meta.xml` |
+| Deploy fails: `isEnabled invalid at this location in type UIBundle` | Metadata uses LWC-style or stale field name | Use `<isActive>true</isActive>` and include `<version>` |
+| Deploy report includes `vite.config.js`, `.d.ts`, or `*.tsbuildinfo` | `tsc -b` emitted TypeScript build artifacts into the bundle root | Use `tsc --noEmit && vite build`, delete artifacts, redeploy |
 | Deploy succeeds but external app site is empty | Forgot to deploy `digitalExperiences/`, `networks/`, or `sites/` | Re-deploy with all four metadata folders |
 | Hard refresh on `/dashboard` returns 404 | `routing.fallback` not set to `index.html` | Add `"fallback": "index.html"` under `routing` |
 | Trailing slash redirects loop | Conflicting `trailingSlash` and `redirects` rules | Set `trailingSlash: "never"`, remove redundant redirects |
@@ -36,6 +40,8 @@ Bucketed by where the failure happens. Each row is a real failure mode seen in M
 | Mutation succeeds but returned record has errors | Field can't be selected on mutation return | Switch call site to **Permissive** error strategy or remove offending fields |
 | `gql` template provides no IntelliSense | GraphQL ESLint plugin / extension not configured | Install `@graphql-eslint/eslint-plugin`; configure `.eslintrc` |
 | Local dev fetches succeed, deployed fetches 401/403 | `basePath` mismatch between dev and deployed surface | Don't hard-code paths; let SDK resolve |
+| React app needs Apex logic from an LWC controller | LWC `@salesforce/apex` imports are unavailable in React UI bundles | Expose Apex as REST and call it through `sdk.fetch?.()` |
+| Apex compile fails: `Invalid type: aiplatform.ModelsAPI...` | Models API / Generative AI settings not enabled for the org | Enable the required org settings; don't replace React Data SDK calls with raw Salesforce fetches |
 
 ## Local dev (Vite)
 
@@ -86,9 +92,10 @@ When something is broken and you're not sure where:
 3. Is `schema.graphql` fresh? Re-run `npm run graphql:schema` and `npm run graphql:codegen`.
 4. Is the org authorized in this shell? `sf org list` then `sf org login web -a alias` if needed.
 5. Is the running user assigned the bundle's permission set?
-6. For ACC: re-walk the [acc-integration.md](acc-integration.md) checklist top to bottom.
-7. For external apps: confirm all four metadata folders deployed.
-8. Compare against the [`multiframework-recipes`](https://github.com/trailheadapps/multiframework-recipes) reference repo for the exact pattern you're trying to use.
+6. Did a second deploy report source-tracking conflicts immediately after a successful create? If yes, and the org changes are your just-created bundle, redeploy the local bundle with `--ignore-conflicts`.
+7. For ACC: re-walk the [acc-integration.md](acc-integration.md) checklist top to bottom.
+8. For external apps: confirm all four metadata folders deployed.
+9. Compare against the [`multiframework-recipes`](https://github.com/trailheadapps/multiframework-recipes) reference repo for the exact pattern you're trying to use.
 
 ## Reporting bugs to Salesforce
 

--- a/skills/sf-multiframework/references/troubleshooting.md
+++ b/skills/sf-multiframework/references/troubleshooting.md
@@ -1,0 +1,101 @@
+# Troubleshooting
+
+Bucketed by where the failure happens. Each row is a real failure mode seen in Multi-Framework Beta projects with the **first** thing to check.
+
+## Setup & enablement
+
+| Symptom | Likely cause | First check |
+|---|---|---|
+| Beta toggle missing in Setup | Org is DE / Trailhead Playground (not supported) | Use a sandbox or scratch org |
+| Beta toggle visible but greyed out | User missing **Customize Application** | Assign System Administrator profile or equivalent permission |
+| App loads in English only / blank screens elsewhere | Org default language ≠ `en_US` | Scratch: set `"language": "en_US"`. Sandbox: change org language |
+| `sf template generate ui-bundle` not recognized | `@salesforce/plugin-ui-bundle-dev` not installed | `sf plugins install @salesforce/plugin-ui-bundle-dev` |
+| `npm install` fails with peer warnings on React 19 | Older deps in template | Upgrade to template's pinned versions, then `npm install` again |
+
+## Project & build
+
+| Symptom | Likely cause | First check |
+|---|---|---|
+| Build succeeds, deploy fails | `outputDir` in `ui-bundle.json` doesn't match Vite `build.outDir` | Align both to `dist` |
+| Deploy fails with file-count error | UIBundle exceeded 2,500 files | Disable source maps in production; prune `dist/` |
+| Deploy succeeds but app missing from App Launcher | `<isActive>false</isActive>` or wrong `<target>` | Set `isActive: true`; confirm target is `AppLauncher` |
+| Deploy succeeds but external app site is empty | Forgot to deploy `digitalExperiences/`, `networks/`, or `sites/` | Re-deploy with all four metadata folders |
+| Hard refresh on `/dashboard` returns 404 | `routing.fallback` not set to `index.html` | Add `"fallback": "index.html"` under `routing` |
+| Trailing slash redirects loop | Conflicting `trailingSlash` and `redirects` rules | Set `trailingSlash: "never"`, remove redundant redirects |
+| Browser console: 404 on `/assets/...` after deploy | Vite `base` not configured for the served path | Set Vite `base` to match Salesforce-served path; rebuild |
+
+## Data SDK / GraphQL
+
+| Symptom | Likely cause | First check |
+|---|---|---|
+| `Cannot read properties of undefined (reading 'value')` | Forgot the UI API `{ value }` field wrapper | Read fields as `record.Name.value` |
+| `edges` is null / empty despite data existing | Filter excludes everything; permission issue | Drop the filter; confirm running user has access |
+| Codegen produces empty or `any` types | `schema.graphql` missing or scalars not mapped | `npm run graphql:schema` then add scalar mappings to `codegen.yml` |
+| `GraphQL surface unavailable` thrown | Running in a surface that doesn't expose `graphql` | Use `sdk.fetch?.()` with allow-listed REST endpoint |
+| 401 on every call after deploy | Bypassing Data SDK | Refactor to `createDataSDK()` / `sdk.graphql?.()` / `sdk.fetch?.()` |
+| Mutation succeeds but returned record has errors | Field can't be selected on mutation return | Switch call site to **Permissive** error strategy or remove offending fields |
+| `gql` template provides no IntelliSense | GraphQL ESLint plugin / extension not configured | Install `@graphql-eslint/eslint-plugin`; configure `.eslintrc` |
+| Local dev fetches succeed, deployed fetches 401/403 | `basePath` mismatch between dev and deployed surface | Don't hard-code paths; let SDK resolve |
+
+## Local dev (Vite)
+
+| Symptom | Likely cause | First check |
+|---|---|---|
+| Vite dev server starts but data calls 401 | No authorized org in this shell | `sf org login web -a alias` |
+| Vite proxy doesn't forward to org | `@salesforce/vite-plugin-ui-bundle` not in `vite.config.ts` | Add the plugin |
+| ACC FAB doesn't appear locally | `localhost` origin not in Trusted Domains | Add `http://localhost:<port>` with iFrame type Lightning Out |
+| HMR doesn't pick up `.graphql` changes | Codegen not re-run | `npm run graphql:codegen` after every `.graphql` edit (or add a watcher) |
+
+## Agentforce Conversation Client (ACC)
+
+| Symptom | Likely cause | First check |
+|---|---|---|
+| FAB never appears | Trusted Domains not added or cookies still restricted | Verify both: My Domain cookie policy off + Trusted Domains entry with iFrame type Lightning Out |
+| Panel opens but disconnects on navigation | Origin mismatch (e.g. wrong port) | Add the **exact** origin including port |
+| Welcome message missing | Agentforce preference disabled | Setup → Einstein → Agentforce Studio → enable Agentforce |
+| Rich Lightning Types render as plain text | Agent action output schema not using a Lightning Type | Update GenAiFunction output schema (delegate to sf-ai-agentforce) |
+| Streaming cuts off mid-response | Network keepalive issue or session expiry | Inspect devtools Network; refresh session; retry |
+| Branding tokens don't apply | SDK option key names differ from docs read | Check installed `@salesforce/agentforce-conversation-client` version's TypeScript declarations |
+| ACC works in prod but not local | `localhost` origin missing from Trusted Domains | Add `http://localhost:<port>` |
+
+## Styling
+
+| Symptom | Likely cause | First check |
+|---|---|---|
+| SLDS classes don't apply | `@salesforce-ux/design-system` CSS not imported globally | Import in `global.css` once at app entry |
+| `design-system-react` icons missing | No `IconSettings` wrapper | Wrap app/component subtree in `<IconSettings iconPath="/assets/icons">` |
+| Tailwind utilities don't override SLDS | Specificity / source order | Pick **one** system per component; don't mix |
+| Dark mode variables don't switch | `.dark` class not applied to `<html>` | Add `class="dark"` toggle on root |
+| Focus ring is grey instead of Salesforce blue | Default shadcn `--ring` token | Set `--ring: #0176d3` in `global.css` |
+
+## External (Experience Cloud) apps
+
+| Symptom | Likely cause | First check |
+|---|---|---|
+| Site shows but app doesn't render | `appContainer` or `appSpace` wrong in `content.json` | `appContainer: true`; `appSpace: "<NamespacePrefix>__<DeveloperName>"` (or `c__<DeveloperName>`) |
+| Site URL 404s | `networks/` or `sites/` not deployed | Deploy all four metadata folders together |
+| User can't log in | Missing Customer / Partner Community license | Provision the right license type |
+| Trying to edit site in Experience Builder | Not supported for React-app sites | Skip Builder; edit via metadata |
+
+## Generic recovery checklist
+
+When something is broken and you're not sure where:
+
+1. Did `npm run build` pass? If no, fix the build first.
+2. Did `npm run lint` pass? Lint errors often mask runtime bugs.
+3. Is `schema.graphql` fresh? Re-run `npm run graphql:schema` and `npm run graphql:codegen`.
+4. Is the org authorized in this shell? `sf org list` then `sf org login web -a alias` if needed.
+5. Is the running user assigned the bundle's permission set?
+6. For ACC: re-walk the [acc-integration.md](acc-integration.md) checklist top to bottom.
+7. For external apps: confirm all four metadata folders deployed.
+8. Compare against the [`multiframework-recipes`](https://github.com/trailheadapps/multiframework-recipes) reference repo for the exact pattern you're trying to use.
+
+## Reporting bugs to Salesforce
+
+This is a **Beta**. Real issues exist beyond what's listed here. When filing:
+
+- Include org type (sandbox / scratch), org language, API version
+- Include `sf --version` and `node -v`
+- Include `package.json` of the bundle (versions of `@salesforce/sdk-data`, `@salesforce/agentforce-conversation-client`)
+- Include exact `ui-bundle.json` and `<app>.uibundle-meta.xml`
+- Reproduce against `multiframework-recipes` if possible to isolate


### PR DESCRIPTION
## Description

> **Heads up:** this is a bigger PR than most skill additions in this repo. It ships 21 reference files, 10 asset templates, and 5 working example components. That's intentional and explained below, but wanted to flag it upfront rather than bury it.

This PR adds `sf-multiframework`, a new skill for building React applications on the Salesforce Agentforce 360 Platform using the `UIBundle` metadata type.

Salesforce Multi-Framework (Beta) lets you deploy React apps (TypeScript, Vite, GraphQL) directly to a Salesforce org via the `sf` CLI, with native data access through `@salesforce/sdk-data` and Agentforce integration via the ACC.

The official docs at https://developer.salesforce.com/docs/platform/einstein-for-devs/guide/reactdev-overview.html cover the concept well but leave a lot of gaps: the Vite config needs specific settings, the GraphQL codegen pipeline is easy to misconfigure, CSP policies silently swallow errors, and the ACC requires a specific component hierarchy. This skill covers the full path from setup to deployed app.

**Why so many files?** The surface area is genuinely wide during beta. Setup, data, GraphQL, ACC, routing, styling, CSP, CI, testing, and troubleshooting are all separate problem spaces, and the asset examples give agents something concrete to work from instead of synthesizing from scratch.

## Why this matters

Multi-Framework is currently sandbox/scratch-org only, so the people most likely to hit it are developers and architects doing early exploration, exactly the audience that benefits most from an opinionated, tested starting point. Without a dedicated skill, agents fall back on generic React knowledge that doesn't account for platform constraints (no `localStorage`, restricted CSP, specific Vite externals, `@salesforce/sdk-data` query patterns that differ from plain Apollo).

There's also a real decision point that keeps coming up: **React vs LWC**. This skill includes a dedicated `lwc-vs-react.md` reference that gives a concrete decision framework instead of a hand-wavy "it depends". Single-page apps with complex state lean React, component library reuse leans LWC, and there are hard constraints on each side that should be documented somewhere.

## What's included

### Skill core
| File | Purpose |
|------|---------|
| `SKILL.md` | Trigger conditions, activation instructions, 100-pt scoring rubric across 6 categories |
| `README.md` | Skill overview, quick-start, cross-skill relationships |
| `CREDITS.md` | Attribution to Jag's framework + official Salesforce sources |

### References (21 files)
| Reference | What it covers |
|-----------|---------------|
| `overview.md` | What Multi-Framework is, platform constraints, beta limitations |
| `setup.md` | Org enablement, permission sets, `@salesforce/plugin-ui-bundle-dev` install |
| `activation-checklist.md` | Step-by-step preflight before scaffolding |
| `project-structure.md` | Directory layout, `uiBundles/`, `sfdx-project.json` integration |
| `cli-guide.md` | `sf template generate ui-bundle`, `sf project deploy start`, full CLI reference |
| `data-sdk.md` | `@salesforce/sdk-data`: `useSalesforceQuery`, `useSalesforceMutation`, provider setup |
| `graphql-workflow.md` | Schema introspection, codegen, typed queries end-to-end |
| `acc-integration.md` | Agentforce Conversation Client: session lifecycle, component hierarchy, message handling |
| `lwc-vs-react.md` | Decision framework: when to use each, hard constraints, migration considerations |
| `styling.md` | SLDS design tokens in React, Lightning Design System import paths, dark mode |
| `permissions-csp.md` | Required permission sets, CSP trusted sites, common silent failures |
| `error-handling.md` | Platform-specific error patterns, org connectivity failures, SDK error shapes |
| `react-router.md` | Client-side routing within UIBundle constraints |
| `authoring-surface.md` | Agentforce Vibes vs direct CLI authoring |
| `ci-deploy.md` | GitHub Actions / CI deployment patterns |
| `testing.md` | Vitest + React Testing Library setup, mocking `@salesforce/sdk-data` |
| `troubleshooting.md` | The errors you will hit: CSP blocks, deploy failures, SDK not found, ACC session issues |
| `official-sources.md` | Curated links to Salesforce docs + `trailheadapps/multiframework-recipes` |
| `recipe-conventions.md` | How to read and adapt the official recipe patterns |
| `scoring-rubric.md` | 100-pt rubric breakdown: Setup/Config (20), Data SDK (20), ACC Integration (20), Styling (15), Error Handling (15), Testing (10) |
| `templates.md` | Template reference and scaffolding patterns |

### Assets
| Asset | Purpose |
|-------|---------|
| `assets/examples/AccChatPanel.tsx` | Full working ACC integration component |
| `assets/examples/SingleRecord.tsx` | Data SDK record fetch with loading/error states |
| `assets/examples/graphqlClient.ts` | GraphQL client setup with `@salesforce/sdk-data` |
| `assets/examples/listAccountsQuery.graphql` | Example typed GraphQL query |
| `assets/examples/global.css` | SLDS token imports for React |
| `assets/templates/vite.config.ts` | Working Vite config with correct externals and UIBundle settings |
| `assets/templates/codegen.yml` | GraphQL Code Generator config for typed operations |
| `assets/templates/ui-bundle.json` | UIBundle manifest template |
| `assets/templates/myApp.uibundle-meta.xml` | Metadata XML template |
| `assets/templates/external-content.json` | ExternalContent configuration |

### Root README updates
- Skill count badge: 36 to 37
- Development area: added `sf-multiframework` alongside `sf-lwc`
- Usage Examples section: new "React / Multi-Framework (UIBundle)" block
- Roadmap table: new row with Beta status indicator
- Install count references updated throughout

## Cross-skill relationships

`sf-multiframework` is designed to work alongside the existing skill family, not replace anything:

- Pair with **sf-lwc** when there's a mixed LWC + React codebase; the `lwc-vs-react.md` reference gives the decision criteria
- Pair with **sf-ai-agentforce** when wiring the ACC; the Agentforce side of the conversation still needs agent metadata
- Pair with **sf-deploy** for CI/CD pipeline setup; UIBundle deploy patterns are included in `ci-deploy.md`
- Pair with **sf-permissions** for CSP policy and permission set troubleshooting

## Type of Change

- [x] New feature (new skill)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring

## Testing

- [x] Frontmatter matches existing skill format (`name`, `description`, `license`, `compatibility`, `metadata.*`)
- [x] Skill trigger conditions are scoped correctly (won't fire on pure LWC, pure Apex, or Builder-only work)
- [x] Sibling links use relative `../skill-name/` style consistent with the rest of the repo
- [x] All reference files present with no dead links
- [x] Asset templates validated against current `@salesforce/plugin-ui-bundle-dev` scaffolding output
- [x] `CREDITS.md` attributes Jag's framework and official Salesforce documentation sources

## Checklist

- [x] Follows existing skill structure (`SKILL.md`, `README.md`, `CREDITS.md`, `LICENSE`, `references/`, `assets/`)
- [x] Root `README.md` updated (category row, usage examples, roadmap status table)
- [x] No breaking changes to existing skills
- [x] No placeholders or stubs -- all referenced files exist
- [x] Beta status clearly labeled throughout (compatibility field, overview, status table)

## Disclosure

Per `CONTRIBUTING.md` AI Usage Policy: content was drafted with AI assistance and hand-reviewed against the official Salesforce Multi-Framework documentation and `trailheadapps/multiframework-recipes`. Asset examples were cross-checked against current `@salesforce/plugin-ui-bundle-dev` scaffolding output and the SDK API surface.

---

Jag, you do incredible work and I know you've got a lot on your plate with the Pi extensions and plugins. Hopefully this takes a little off the list. Happy to iterate on anything here, looking forward to your feedback.